### PR TITLE
Change conditions in Json content object to prevent errors with strict types

### DIFF
--- a/Classes/ContentObject/JsonContentObject.php
+++ b/Classes/ContentObject/JsonContentObject.php
@@ -174,7 +174,7 @@ class JsonContentObject extends AbstractContentObject
                 } else {
                     $json[$key] = json_decode($singleData);
                 }
-            } else if (is_array($singleData) || is_object(($singleData))) {
+            } else if (is_array($singleData)) {
                 $json[$key] = $this->decodeFieldsIfRequired($singleData);
             }
             else {

--- a/Classes/ContentObject/JsonContentObject.php
+++ b/Classes/ContentObject/JsonContentObject.php
@@ -168,17 +168,17 @@ class JsonContentObject extends AbstractContentObject
         $json = [];
 
         foreach ($data as $key => $singleData) {
-            if (!is_array($singleData) && !is_object($singleData) && !is_int($singleData) && $singleData !== null) {
+            if (is_string($singleData)) {
                 if (json_decode($singleData) === null) {
                     $json[$key] = $singleData;
                 } else {
                     $json[$key] = json_decode($singleData);
                 }
-            } else if (is_object($singleData) || is_int($singleData) || $singleData === null) {
-                $json[$key] = $singleData;
+            } else if (is_array($singleData) || is_object(($singleData))) {
+                $json[$key] = $this->decodeFieldsIfRequired($singleData);
             }
             else {
-                $json[$key] = $this->decodeFieldsIfRequired($singleData);
+                $json[$key] = $singleData;
             }
         }
         return $json;


### PR DESCRIPTION
Simplify condition in JSON Content object, handle also missing case with float or boolean condition.