### PR TITLE
[FEATURE] Output error for missing rendering definition in JSON

### DIFF
--- a/Configuration/TypoScript/ContentElement/Default.typoscript
+++ b/Configuration/TypoScript/ContentElement/Default.typoscript
@@ -1,0 +1,10 @@
+tt_content.default >
+tt_content.default =< lib.contentElement
+tt_content.default.fields {
+    content = TEXT
+    content {
+        field = CType
+        wrap = ERROR: Content Element with uid "{field:uid}" and type "|" has no rendering definition!
+        wrap.insertData = 1
+    }
+}


### PR DESCRIPTION
When a rendering definition (TypoScript) is missing for a content element (e.g when TypoScript is not included or incorrect) the output of the "content" is as follows:
```json
"colPos": [
  null,
  null
],
```
This makes it harder to track down the problem. When overriding `tt_content.default` and adding the error output to the JSON, debugging is much easier. :)

New output inside the correct colPos array is:
```json
{
    "appearance": {
        "frameClass": "default",
        "layout": "default",
        "spaceAfter": "",
        "spaceBefore": ""
    },
    "colPos": 0,
    "content": "ERROR: Content Element with uid \"3\" and type \"tx_myextension_contentelement\" has no rendering definition!",
    "id": 3,
    "pid": 1,
    "type": "tx_myextension_contentelement"
}
```


besr,
R