### PR TITLE
[TASK] Prevent conflicts with fluid_styled_content and bootstrap_package

### DIFF
--- a/Configuration/TypoScript/ContentElement/Bullets.typoscript
+++ b/Configuration/TypoScript/ContentElement/Bullets.typoscript
@@ -1,3 +1,4 @@
+tt_content.bullets >
 tt_content.bullets =< lib.contentElementWithHeader
 tt_content.bullets {
     fields {

--- a/Configuration/TypoScript/ContentElement/Div.typoscript
+++ b/Configuration/TypoScript/ContentElement/Div.typoscript
@@ -1,3 +1,4 @@
+tt_content.div >
 tt_content.div =< lib.contentElement
 tt_content.div {
     fields {

--- a/Configuration/TypoScript/ContentElement/Header.typoscript
+++ b/Configuration/TypoScript/ContentElement/Header.typoscript
@@ -1,1 +1,2 @@
+tt_content.header >
 tt_content.header =< lib.contentElementWithHeader

--- a/Configuration/TypoScript/ContentElement/Html.typoscript
+++ b/Configuration/TypoScript/ContentElement/Html.typoscript
@@ -1,3 +1,4 @@
+tt_content.html >
 tt_content.html =< lib.contentElement
 tt_content.html {
     fields {

--- a/Configuration/TypoScript/ContentElement/Image.typoscript
+++ b/Configuration/TypoScript/ContentElement/Image.typoscript
@@ -1,3 +1,4 @@
+tt_content.image >
 tt_content.image =< lib.contentElementWithHeader
 tt_content.image {
     fields {

--- a/Configuration/TypoScript/ContentElement/List.typoscript
+++ b/Configuration/TypoScript/ContentElement/List.typoscript
@@ -1,3 +1,4 @@
+tt_content.list >
 tt_content.list =< lib.contentElementWithHeader
 tt_content.list {
     fields {

--- a/Configuration/TypoScript/ContentElement/MenuAbstract.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuAbstract.typoscript
@@ -1,3 +1,4 @@
+tt_content.menu_abstract >
 tt_content.menu_abstract =< lib.contentElementWithHeader
 tt_content.menu_abstract {
     fields {

--- a/Configuration/TypoScript/ContentElement/MenuCategorizedContent.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuCategorizedContent.typoscript
@@ -1,3 +1,4 @@
+tt_content.menu_categorized_content >
 tt_content.menu_categorized_content =< lib.contentElementWithHeader
 tt_content.menu_categorized_content {
     fields {

--- a/Configuration/TypoScript/ContentElement/MenuCategorizedPages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuCategorizedPages.typoscript
@@ -1,3 +1,4 @@
+tt_content.menu_categorized_pages >
 tt_content.menu_categorized_pages =< lib.contentElementWithHeader
 tt_content.menu_categorized_pages {
     fields {

--- a/Configuration/TypoScript/ContentElement/MenuPages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuPages.typoscript
@@ -1,4 +1,5 @@
-tt_content.menu_pages =< =< lib.contentElementWithHeader
+tt_content.menu_pages >
+tt_content.menu_pages =< lib.contentElementWithHeader
 tt_content.menu_pages {
     fields {
         content {

--- a/Configuration/TypoScript/ContentElement/MenuRecentlyUpdated.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuRecentlyUpdated.typoscript
@@ -1,3 +1,4 @@
+tt_content.menu_recently_updated >
 tt_content.menu_recently_updated =< lib.contentElementWithHeader
 tt_content.menu_recently_updated {
     fields {

--- a/Configuration/TypoScript/ContentElement/MenuRelatedPages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuRelatedPages.typoscript
@@ -1,3 +1,4 @@
+tt_content.menu_related_pages >
 tt_content.menu_related_pages =< lib.contentElementWithHeader
 tt_content.menu_related_pages {
     fields {

--- a/Configuration/TypoScript/ContentElement/MenuSection.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSection.typoscript
@@ -1,3 +1,4 @@
+tt_content.menu_section >
 tt_content.menu_section =< lib.contentElementWihHeader
 tt_content.menu_section {
     fields {

--- a/Configuration/TypoScript/ContentElement/MenuSectionPages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSectionPages.typoscript
@@ -1,3 +1,4 @@
+tt_content.menu_section_pages >
 tt_content.menu_section_pages =< lib.contentElementWithHeader
 tt_content.menu_section_pages {
     fields {

--- a/Configuration/TypoScript/ContentElement/MenuSitemap.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSitemap.typoscript
@@ -1,3 +1,4 @@
+tt_content.menu_sitemap >
 tt_content.menu_sitemap =< lib.contentElementWithHeader
 tt_content.menu_sitemap {
     fields {

--- a/Configuration/TypoScript/ContentElement/MenuSitemapPages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSitemapPages.typoscript
@@ -1,3 +1,4 @@
+tt_content.menu_sitemap_pages >
 tt_content.menu_sitemap_pages =< lib.contentElementWithHeader
 tt_content.menu_sitemap_pages {
     fields {

--- a/Configuration/TypoScript/ContentElement/MenuSubpages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSubpages.typoscript
@@ -1,3 +1,4 @@
+tt_content.menu_subpages >
 tt_content.menu_subpages =< lib.contentElementWithHeader
 tt_content.menu_subpages {
     fields {

--- a/Configuration/TypoScript/ContentElement/Shortcut.typoscript
+++ b/Configuration/TypoScript/ContentElement/Shortcut.typoscript
@@ -1,3 +1,4 @@
+tt_content.shortcut >
 tt_content.shortcut =< lib.contentElement
 tt_content.shortcut {
     fields {

--- a/Configuration/TypoScript/ContentElement/Table.typoscript
+++ b/Configuration/TypoScript/ContentElement/Table.typoscript
@@ -1,3 +1,4 @@
+tt_content.table >
 tt_content.table =< lib.contentElementWithHeader
 tt_content.table {
     fields {

--- a/Configuration/TypoScript/ContentElement/Text.typoscript
+++ b/Configuration/TypoScript/ContentElement/Text.typoscript
@@ -1,3 +1,4 @@
+tt_content.text >
 tt_content.text =< lib.contentElementWithHeader
 tt_content.text {
     fields {

--- a/Configuration/TypoScript/ContentElement/Textmedia.typoscript
+++ b/Configuration/TypoScript/ContentElement/Textmedia.typoscript
@@ -1,3 +1,4 @@
+tt_content.textmedia >
 tt_content.textmedia =< lib.contentElementWithHeader
 tt_content.textmedia {
     fields {

--- a/Configuration/TypoScript/ContentElement/Textpic.typoscript
+++ b/Configuration/TypoScript/ContentElement/Textpic.typoscript
@@ -1,3 +1,4 @@
+tt_content.textpic >
 tt_content.textpic =< lib.contentElementWithHeader
 tt_content.textpic {
     fields {

--- a/Configuration/TypoScript/ContentElement/Uploads.typoscript
+++ b/Configuration/TypoScript/ContentElement/Uploads.typoscript
@@ -1,3 +1,4 @@
+tt_content.uploads >
 tt_content.uploads =< lib.contentElement
 tt_content.uploads {
     fields {

--- a/Configuration/TypoScript/Helper/Appearance.typoscript
+++ b/Configuration/TypoScript/Helper/Appearance.typoscript
@@ -1,3 +1,4 @@
+lib.appearance >
 lib.appearance = JSON
 lib.appearance {
     fields {

--- a/Configuration/TypoScript/Helper/Breadcrumbs.typoscript
+++ b/Configuration/TypoScript/Helper/Breadcrumbs.typoscript
@@ -1,3 +1,4 @@
+lib.breadcrumbs >
 lib.breadcrumbs = JSON
 lib.breadcrumbs {
     dataProcessing {

--- a/Configuration/TypoScript/Helper/Content.typoscript
+++ b/Configuration/TypoScript/Helper/Content.typoscript
@@ -1,3 +1,4 @@
+lib.content >
 lib.content = USER
 lib.content {
     userFunc = FriendsOfTYPO3\Headless\Utility\ContentUtility->groupContent

--- a/Configuration/TypoScript/Helper/ContentElementWithHeader.typoscript
+++ b/Configuration/TypoScript/Helper/ContentElementWithHeader.typoscript
@@ -1,3 +1,4 @@
+lib.contentElementWithHeader >
 lib.contentElementWithHeader =< lib.contentElement
 lib.contentElementWithHeader {
     fields {

--- a/Configuration/TypoScript/Helper/DoktypeName.typoscript
+++ b/Configuration/TypoScript/Helper/DoktypeName.typoscript
@@ -1,3 +1,4 @@
+lib.doktypeName >
 lib.doktypeName = CASE
 lib.doktypeName {
   key =

--- a/Configuration/TypoScript/Helper/Languages.typoscript
+++ b/Configuration/TypoScript/Helper/Languages.typoscript
@@ -1,3 +1,4 @@
+lib.languages >
 lib.languages = JSON
 lib.languages {
     dataProcessing {

--- a/Configuration/TypoScript/Helper/Navigation.typoscript
+++ b/Configuration/TypoScript/Helper/Navigation.typoscript
@@ -1,3 +1,4 @@
+lib.primaryNavigation >
 lib.primaryNavigation = JSON
 lib.primaryNavigation {
     dataProcessing {

--- a/Configuration/TypoScript/Helper/Page.typoscript
+++ b/Configuration/TypoScript/Helper/Page.typoscript
@@ -1,3 +1,4 @@
+lib.page >
 lib.page = JSON
 lib.page {
     fields {

--- a/Configuration/TypoScript/Helper/ParseFunc.typoscript
+++ b/Configuration/TypoScript/Helper/ParseFunc.typoscript
@@ -1,4 +1,5 @@
 # Creates persistent ParseFunc setup for non-HTML content.
+lib.parseFunc >
 lib.parseFunc {
     makelinks = 1
     makelinks {
@@ -48,6 +49,7 @@ lib.parseFunc {
 
 
 # Creates persistent ParseFunc setup for RTE content (which is mainly HTML) based on the "default" transformation.
+lib.parseFunc_RTE >
 lib.parseFunc_RTE < lib.parseFunc
 lib.parseFunc_RTE {
     # Processing <ol>, <ul> and <table> blocks separately
@@ -118,6 +120,7 @@ lib.parseFunc_RTE {
     }
 }
 
+lib.parseFunc_links >
 lib.parseFunc_links {
     tags {
         link = TEXT

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,6 @@
   "require": {
     "typo3/cms-core": "^9.5 || ^10.0"
   },
-  "conflict": {
-    "typo3/cms-fluid-styled-content": "*",
-    "bk2k/bootstrap-package": "*"
-  },
   "autoload": {
     "psr-4": {
       "FriendsOfTYPO3\\Headless\\": "Classes"

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,10 @@
   "require": {
     "typo3/cms-core": "^9.5 || ^10.0"
   },
+  "conflict": {
+    "typo3/cms-fluid-styled-content": "*",
+    "bk2k/bootstrap-package": "*"
+  },
   "autoload": {
     "psr-4": {
       "FriendsOfTYPO3\\Headless\\": "Classes"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,10 +14,6 @@ $EM_CONF[$_EXTKEY] = [
             'typo3' => '9.5.0-10.0.99',
             'frontend' => '9.5.0-10.0.99'
         ],
-        'conflicts' => [
-            'fluid_styled_content' => '*',
-            'bootstrap_package' => '*'
-        ],
         'suggests' => [],
     ],
 ];

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,7 +14,10 @@ $EM_CONF[$_EXTKEY] = [
             'typo3' => '9.5.0-10.0.99',
             'frontend' => '9.5.0-10.0.99'
         ],
-        'conflicts' => [],
+        'conflicts' => [
+            'fluid_styled_content' => '*',
+            'bootstrap_package' => '*'
+        ],
         'suggests' => [],
     ],
 ];

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,6 +14,7 @@ $EM_CONF[$_EXTKEY] = [
             'typo3' => '9.5.0-10.0.99',
             'frontend' => '9.5.0-10.0.99'
         ],
+        'conflicts' => [],
         'suggests' => [],
     ],
 ];


### PR DESCRIPTION
When `EXT:fluid_styled_content` or `EXT:bootstrap_package` is installed and included the JSON output of `EXT:headless` is broken. To prevent this I added these two conflicting extensions to "conflicts" in `ext_emconf.php` and `composer.json`.

Additionally to make sure that nothing ever will affect the `tt_content.*` TypoScript I cleared it before using it.

best,
R