### PR TITLE
[TASK] Change lib.doktypeName key value

### DIFF
--- a/Configuration/TypoScript/Helper/DoktypeName.typoscript
+++ b/Configuration/TypoScript/Helper/DoktypeName.typoscript
@@ -1,6 +1,6 @@
 lib.doktypeName = CASE
 lib.doktypeName {
-  key.field = doktype
+  key = field:doktype
 
   3 = TEXT
   3.value = Link


### PR DESCRIPTION
When using the `lib.doktypeName` for rendering doktype names where the doktype is not coming from the `doktype` field (e.g from a comma-separated list of doktypes) it is impossible to override the previously set `key.field = doktype`. For this it should be changed to `key = field:doktype`.

Don't know exactly why, but I just could not override the `key.field` for given example:
```
types = TEXT
types {
    data = flexform:pi_flexform:doktypes
    split {
        token = ,
        cObjNum = 1 |*| 2 |*| 3

        1 {
            current = 1
            wrap = |,

            cObject =< lib.doktypeName
            cObject.key.data = current
        }

        2 < .1

        3 < .1
        3.wrap = |
    }
}
```