### PR TITLE
[TASK]  Change ImagesProcessor to FilesProcessor, output data directly, without additional nesting level

### DIFF
--- a/Classes/DataProcessing/FilesProcessor.php
+++ b/Classes/DataProcessing/FilesProcessor.php
@@ -26,9 +26,9 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
 use TYPO3\CMS\Frontend\ContentObject\Exception\ContentRenderingException;
 
 /**
- * Class ImagesProcessor
+ * Class FilesProcessor
  */
-class ImageProcessor implements DataProcessorInterface
+class FilesProcessor implements DataProcessorInterface
 {
     /**
      * @var array
@@ -88,18 +88,18 @@ class ImageProcessor implements DataProcessorInterface
         $this->contentObjectRenderer = $cObj;
         $this->processorConfiguration = $processorConfiguration;
 
-        $filesProcessedDataKey = (string)$cObj->stdWrapValue(
+        $filesProcessedDataKey = (string) $cObj->stdWrapValue(
             'filesProcessedDataKey',
             $processorConfiguration,
             $this->defaults['filesAs']
         );
-        $galleryProcessedDataKey = (string)$cObj->stdWrapValue(
+        $galleryProcessedDataKey = (string) $cObj->stdWrapValue(
             'galleryProcessedDataKey',
             $processorConfiguration,
             $this->defaults['galleryAs']
         );
 
-        $targetFieldName = (string)$cObj->stdWrapValue(
+        $targetFieldName = (string) $cObj->stdWrapValue(
             'as',
             $processorConfiguration,
             $this->defaults['as']
@@ -127,7 +127,7 @@ class ImageProcessor implements DataProcessorInterface
 
         foreach ($this->fileObjects as $fileObject) {
             $metaData = $fileObject->toArray();
-            $data['images'][] = [
+            $data[] = [
                 'publicUrl' => $this->getImageService()->getImageUri($fileObject, true),
                 'dimensions' => [
                     'width' => $fileObject->getProperty('width'),
@@ -164,7 +164,7 @@ class ImageProcessor implements DataProcessorInterface
                     'height' => $image['dimensions']['height']
                 ]);
                 $metaData = $image['media']->toArray();
-                $data['images'][] = [
+                $data[] = [
                     'publicUrl' => $this->getImageService()->getImageUri($processedFile, true),
                     'dimensions' => [
                         'width' => $processedFile->getProperty('width'),

--- a/Configuration/TypoScript/ContentElement/Image.typoscript
+++ b/Configuration/TypoScript/ContentElement/Image.typoscript
@@ -20,7 +20,7 @@ tt_content.image {
                             borderPadding = {$styles.content.textmedia.borderPadding}
                             as = image
                         }
-                        30 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                        30 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                         30 {
                             as = images
                         }

--- a/Configuration/TypoScript/ContentElement/MenuAbstract.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuAbstract.typoscript
@@ -17,7 +17,7 @@ tt_content.menu_abstract {
                                     references.fieldName = media
                                     as = files
                                 }
-                                20 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                                20 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                                 20 {
                                     as = images
                                 }

--- a/Configuration/TypoScript/ContentElement/MenuCategorizedContent.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuCategorizedContent.typoscript
@@ -24,7 +24,7 @@ tt_content.menu_categorized_content {
                                 10 {
                                     references.fieldName = image
                                 }
-                                20 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                                20 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                                 20 {
                                     as = images
                                 }

--- a/Configuration/TypoScript/ContentElement/MenuCategorizedPages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuCategorizedPages.typoscript
@@ -21,7 +21,7 @@ tt_content.menu_categorized_pages {
                                 10 {
                                     references.fieldName = media
                                 }
-                                20 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                                20 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                                 20 {
                                     as = images
                                 }

--- a/Configuration/TypoScript/ContentElement/MenuRecentlyUpdated.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuRecentlyUpdated.typoscript
@@ -20,7 +20,7 @@ tt_content.menu_recently_updated {
                                 10 {
                                     references.fieldName = media
                                 }
-                                20 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                                20 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                                 20 {
                                     as = images
                                 }

--- a/Configuration/TypoScript/ContentElement/MenuRelatedPages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuRelatedPages.typoscript
@@ -20,7 +20,7 @@ tt_content.menu_related_pages {
                                 10 {
                                     references.fieldName = media
                                 }
-                                20 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                                20 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                                 20 {
                                     as = images
                                 }

--- a/Configuration/TypoScript/ContentElement/MenuSectionPages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSectionPages.typoscript
@@ -16,7 +16,7 @@ tt_content.menu_section_pages {
                                 10 {
                                     references.fieldName = media
                                 }
-                                20 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                                20 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                                 20 {
                                     as = images
                                 }
@@ -31,7 +31,7 @@ tt_content.menu_section_pages {
                                         10 {
                                             references.fieldName = image
                                         }
-                                        20 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                                        20 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                                         20 {
                                             as = images
                                         }

--- a/Configuration/TypoScript/ContentElement/MenuSitemap.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSitemap.typoscript
@@ -15,7 +15,7 @@ tt_content.menu_sitemap {
                                 10 {
                                     references.fieldName = media
                                 }
-                                20 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                                20 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                                 20 {
                                     as = images
                                 }

--- a/Configuration/TypoScript/ContentElement/MenuSitemapPages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSitemapPages.typoscript
@@ -17,7 +17,7 @@ tt_content.menu_sitemap_pages {
                                 10 {
                                     references.fieldName = media
                                 }
-                                20 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                                20 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                                 20 {
                                     as = images
                                 }

--- a/Configuration/TypoScript/ContentElement/Textmedia.typoscript
+++ b/Configuration/TypoScript/ContentElement/Textmedia.typoscript
@@ -25,7 +25,7 @@ tt_content.textmedia {
                             borderPadding = {$styles.content.textmedia.borderPadding}
                             as = gallery
                         }
-                        30 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                        30 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                         30 {
                             as = images
                         }

--- a/Configuration/TypoScript/ContentElement/Textpic.typoscript
+++ b/Configuration/TypoScript/ContentElement/Textpic.typoscript
@@ -25,7 +25,7 @@ tt_content.textpic {
                             borderPadding = {$styles.content.textmedia.borderPadding}
                             as = gallery
                         }
-                        30 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                        30 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                         30 {
                             as = images
                         }

--- a/Configuration/TypoScript/ContentElement/Uploads.typoscript
+++ b/Configuration/TypoScript/ContentElement/Uploads.typoscript
@@ -13,7 +13,7 @@ tt_content.uploads {
                             sorting.field = filelink_sorting
                             sorting.direction.field = filelink_sorting_direction
                         }
-                        20 = FriendsOfTYPO3\Headless\DataProcessing\ImageProcessor
+                        20 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                         20 {
                             as = images
                         }


### PR DESCRIPTION
Change ImagesProcessor to FilesProcessor, output data directly, without additional nesting level

Rename DataProcessor, change to all files using ImageProcessor. Remove additional array 'images' to provide clean output.