### PR TITLE
[BUGFIX] Remove double image processing

### DIFF
--- a/Classes/DataProcessing/GalleryProcessor.php
+++ b/Classes/DataProcessing/GalleryProcessor.php
@@ -118,9 +118,6 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
         for ($row = 1; $row <= $this->galleryData['count']['rows']; $row++) {
             for ($column = 1; $column <= $this->galleryData['count']['columns']; $column++) {
                 $fileKey = (($row - 1) * $this->galleryData['count']['columns']) + $column - 1;
-                if ($this->fileObjects[$fileKey]['properties']['type'] === 'image') {
-                    $this->fileObjects[$fileKey] = $this->getFileUtility()->processFile($this->getImageService()->getImage($this->fileObjects[$fileKey]['properties']['fileReferenceUid'], null, true), $this->mediaDimensions[$fileKey] ?? []);
-                }
                 if ($this->fileObjects[$fileKey]) {
                     $this->galleryData['rows'][$row]['columns'][$column] = $this->fileObjects[$fileKey];
                 }


### PR DESCRIPTION
Images in this function was processing before. 
In TYPO3 v10 was also error because getImage() need string but int is given