### PR TITLE
[BUGFIX] Ignore negative colpos values

### DIFF
--- a/Classes/Utility/ContentUtility.php
+++ b/Classes/Utility/ContentUtility.php
@@ -55,7 +55,9 @@ class ContentUtility
             );
 
             $element = json_decode($element);
-            $data['colPos' . $element->colPos][] = $element;
+            if($element->colPos >= 0) {
+                $data['colPos' . $element->colPos][] = $element;
+            }
         }
 
         return $data;

--- a/Classes/Utility/ContentUtility.php
+++ b/Classes/Utility/ContentUtility.php
@@ -55,7 +55,7 @@ class ContentUtility
             );
 
             $element = json_decode($element);
-            if($element->colPos >= 0) {
+            if ($element->colPos >= 0) {
                 $data['colPos' . $element->colPos][] = $element;
             }
         }


### PR DESCRIPTION
Hi @tmotyl,
hi @lukaszuznanski ,

a content element with negative colpos value should be ignored in the json output (e.g when using gridelements).

Feel free to ask any further questions :)

best,
R. Schlosser