### PR TITLE
Make cropVariant configurable through processingConfiguration in FilesProcessor

### DIFF
--- a/Classes/DataProcessing/FilesProcessor.php
+++ b/Classes/DataProcessing/FilesProcessor.php
@@ -165,8 +165,10 @@ class FilesProcessor implements DataProcessorInterface
     {
         $data = [];
 
+        $cropVariant = isset($this->processorConfiguration['processingConfiguration.']['cropVariant']) ? $this->processorConfiguration['processingConfiguration.']['cropVariant'] : 'default';
+
         foreach ($this->fileObjects as $fileObject) {
-            $data[] = $this->getFileUtility()->processFile($fileObject, $dimensions);
+            $data[] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
         }
         return $data;
     }


### PR DESCRIPTION
I had the challenge to make use of cropVariants defined in every Image Element. So I found that headless sets it to "default" and there was no option to get it respected.