### PR TITLE
[FEATURE] add initial support for ext: form

### DIFF
--- a/Classes/Form/CustomOptionsInterface.php
+++ b/Classes/Form/CustomOptionsInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Form;
+
+interface CustomOptionsInterface
+{
+    /**
+     * @return array<string|int,mixed>
+     */
+    public function get(): array;
+}

--- a/Classes/Form/Decorator/AbstractFormDefinitionDecorator.php
+++ b/Classes/Form/Decorator/AbstractFormDefinitionDecorator.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Form\Decorator;
+
+abstract class AbstractFormDefinitionDecorator implements DefinitionDecoratorInterface
+{
+    /**
+     * @param array<mixed> $definition
+     * @return array<string,array<mixed>>
+     */
+    public function __invoke(array $definition, int $currentPage): array
+    {
+        $decorated = [];
+
+        $pageElements = $definition['renderables'][$currentPage]['renderables'] ?? [];
+
+        foreach ($pageElements as &$element) {
+            $element['name'] = 'tx_form_formframework[' . $element['identifier'] . ']';
+
+            $element = $this->overrideElement($element);
+
+            if (\in_array($element['type'], ['ImageUpload', 'FileUpload'])) {
+                unset($element['properties']['saveToFileMount']);
+            }
+
+            if (!isset($element['validators'])) {
+                continue;
+            }
+
+            foreach ($element['validators'] as &$validator) {
+                if ($validator['identifier'] === 'RegularExpression') {
+                    $validator['options']['regularExpression'] = trim(
+                        $validator['options']['regularExpression'],
+                        '/'
+                    );
+                }
+            }
+        }
+
+        $decorated['identifier'] = $definition['identifier'];
+        $decorated['i18n'] = $definition['i18n']['properties'] ?? [];
+        $decorated['elements'] = $pageElements;
+
+        return $this->overrideDefinition($decorated, $definition, $currentPage);
+    }
+
+    /**
+     * @param array<string, mixed> $element
+     * @return array<string, mixed>
+     */
+    protected function overrideElement(array $element): array
+    {
+        return $element;
+    }
+
+    /**
+     * @param array<string, mixed> $decorated
+     * @param array<string, mixed> $definition
+     * @param int $currentPage
+     * @return array<string, mixed>
+     */
+    protected function overrideDefinition(array $decorated, array $definition, int $currentPage): array
+    {
+        return $decorated;
+    }
+}

--- a/Classes/Form/Decorator/DefinitionDecoratorInterface.php
+++ b/Classes/Form/Decorator/DefinitionDecoratorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Form\Decorator;
+
+interface DefinitionDecoratorInterface
+{
+    /**
+     * @param array<mixed> $definition
+     * @return array<string,array<mixed>>
+     */
+    public function __invoke(array $definition, int $currentPage): array;
+}

--- a/Classes/Form/Decorator/FormDefinitionDecorator.php
+++ b/Classes/Form/Decorator/FormDefinitionDecorator.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Form\Decorator;
+
+final class FormDefinitionDecorator extends AbstractFormDefinitionDecorator
+{
+}

--- a/Classes/Form/Finisher/JsonRedirectFinisher.php
+++ b/Classes/Form/Finisher/JsonRedirectFinisher.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Form\Finisher;
+
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
+use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
+
+/**
+ * This finisher redirects to another Controller.
+ *
+ * Scope: frontend
+ */
+class JsonRedirectFinisher extends AbstractFinisher
+{
+    /**
+     * @var array<string, mixed>
+     */
+    protected $defaultOptions = [
+        'pageUid' => 1,
+        'additionalParameters' => '',
+        'message' => null,
+    ];
+
+    /**
+     * @var \TYPO3\CMS\Extbase\Mvc\Web\Request
+     */
+    protected $request;
+
+    /**
+     * @var \TYPO3\CMS\Extbase\Mvc\Web\Response
+     */
+    protected $response;
+
+    /**
+     * @var \TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder
+     */
+    protected $uriBuilder;
+
+    /**
+     * Executes this finisher
+     * @see AbstractFinisher::execute()
+     */
+    protected function executeInternal(): ?string
+    {
+        $formRuntime = $this->finisherContext->getFormRuntime();
+        $this->request = $formRuntime->getRequest();
+        $this->response = $formRuntime->getResponse();
+        $this->uriBuilder = $this->objectManager->get(UriBuilder::class);
+        $this->uriBuilder->setRequest($this->request);
+
+        /**
+         * @var string|int|null
+         */
+        $pageUid = $this->parseOption('pageUid');
+
+        if (is_string($pageUid)) {
+            $pageUid = (int)str_replace('pages_', '', $pageUid);
+        } else {
+            $pageUid = (int)$pageUid;
+        }
+
+        /**
+         * @var string|null
+         */
+        $message = $this->parseOption('message');
+        $additionalParameters = $this->parseOption('additionalParameters');
+        $additionalParameters = is_string($additionalParameters) ? $additionalParameters : '';
+        $additionalParameters = '&' . ltrim($additionalParameters, '&');
+
+        $this->finisherContext->cancel();
+
+        return $this->prepareRedirect($pageUid, $additionalParameters, $message);
+    }
+
+    /**
+     * @param int $pageUid Target page uid. If NULL, the current page uid is used
+     * @param string $additionalParameters
+     * @param string|null $message (optional)
+     * @return string|null
+     */
+    protected function prepareRedirect(
+        int $pageUid = 1,
+        string $additionalParameters = '',
+        ?string $message = null
+    ): ?string {
+        $typolinkConfiguration = [
+            'parameter' => $pageUid,
+            'additionalParams' => $additionalParameters,
+        ];
+        /**
+         * @phpstan-ignore-next-line
+         */
+        $redirectUri = $this->getTypoScriptFrontendController()->cObj->typoLink_URL($typolinkConfiguration);
+
+        try {
+            return \json_encode(
+                [
+                    'message' => $message,
+                    'redirectUri' => $redirectUri,
+                ],
+                \PHP_VERSION_ID >= 70300 ? \JSON_THROW_ON_ERROR : 0
+            );
+        } catch (\JsonException $e) {
+            return null;
+        }
+    }
+}

--- a/Classes/Form/Service/FormTranslationService.php
+++ b/Classes/Form/Service/FormTranslationService.php
@@ -1,0 +1,307 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Form\Service;
+
+use InvalidArgumentException;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\Exception\MissingArrayPathException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Form\Service\TranslationService;
+
+class FormTranslationService extends TranslationService
+{
+    /**
+     * @return FormTranslationService
+     */
+    public static function getInstance(): self
+    {
+        return GeneralUtility::makeInstance(FormTranslationService::class);
+    }
+
+    /**
+     * @param array<string,mixed> $element
+     * @param array<int,mixed> $propertyParts
+     * @param array<string,mixed> $formRuntime
+     * @return string|array<int,string>
+     * @throws InvalidArgumentException
+     * @internal
+     */
+    public function translateElementValue(
+        array $element,
+        array $propertyParts,
+        array $formRuntime
+    ) {
+        if (empty($propertyParts)) {
+            throw new InvalidArgumentException('The argument "propertyParts" is empty', 1476216007);
+        }
+
+        $propertyType = 'properties';
+        $property = implode('.', $propertyParts);
+        $renderingOptions = $element['renderingOptions'] ?? [];
+        $element['properties'] = $element['properties'] ?? [];
+
+        if ($property === 'label') {
+            $defaultValue = $element['label'] ?? '';
+        } elseif ($element['type'] !== 'Page') {
+            try {
+                $defaultValue = ArrayUtility::getValueByPath($element['properties'], $propertyParts, '.');
+            } catch (MissingArrayPathException $exception) {
+                $defaultValue = null;
+            }
+        } else {
+            $propertyType = 'renderingOptions';
+            try {
+                $defaultValue = ArrayUtility::getValueByPath($renderingOptions, $propertyParts, '.');
+            } catch (MissingArrayPathException $exception) {
+                $defaultValue = null;
+            }
+        }
+
+        $translatePropertyValueIfEmpty = $renderingOptions['translation']['translatePropertyValueIfEmpty'] ?? true;
+
+        if (empty($defaultValue) && !$translatePropertyValueIfEmpty) {
+            return $defaultValue;
+        }
+
+        $defaultValue = empty($defaultValue) ? '' : $defaultValue;
+        $translationFiles = $renderingOptions['translation']['translationFiles'] ?? [];
+        if (empty($translationFiles)) {
+            $formRuntime['renderingOptions'] = $formRuntime['renderingOptions'] ?? [];
+            $translationFiles = $formRuntime['renderingOptions']['translation']['translationFiles'];
+        }
+
+        $translationFiles = $this->sortArrayWithIntegerKeysDescending($translationFiles);
+        $language = $renderingOptions['translation']['language'] ?? null;
+
+        try {
+            $arguments = ArrayUtility::getValueByPath(
+                $renderingOptions['translation']['arguments'] ?? [],
+                $propertyParts,
+                '.'
+            );
+        } catch (MissingArrayPathException $e) {
+            $arguments = [];
+        }
+
+        $originalFormIdentifier = null;
+        if (isset($formRuntime['renderingOptions']['_originalIdentifier'])) {
+            $originalFormIdentifier = $formRuntime['renderingOptions']['_originalIdentifier'];
+        }
+
+        if ($property === 'options' && is_array($defaultValue)) {
+            foreach ($defaultValue as $optionValue => &$optionLabel) {
+                $translationKeyChain = [];
+                foreach ($translationFiles as $translationFile) {
+                    if (!empty($originalFormIdentifier)) {
+                        $translationKeyChain[] = sprintf(
+                            '%s:%s.element.%s.%s.%s.%s',
+                            $translationFile,
+                            $originalFormIdentifier,
+                            $element['identifier'],
+                            $propertyType,
+                            $property,
+                            $optionValue
+                        );
+                    }
+                    $translationKeyChain[] = sprintf(
+                        '%s:%s.element.%s.%s.%s.%s',
+                        $translationFile,
+                        $formRuntime['identifier'],
+                        $element['identifier'],
+                        $propertyType,
+                        $property,
+                        $optionValue
+                    );
+                    $translationKeyChain[] = sprintf(
+                        '%s:element.%s.%s.%s.%s',
+                        $translationFile,
+                        $element['identifier'],
+                        $propertyType,
+                        $property,
+                        $optionValue
+                    );
+                    $translationKeyChain[] = sprintf(
+                        '%s:element.%s.%s.%s.%s',
+                        $translationFile,
+                        $element['type'],
+                        $propertyType,
+                        $property,
+                        $optionValue
+                    );
+                }
+
+                $translatedValue = $this->processTranslationChain($translationKeyChain, $language, $arguments);
+                $optionLabel = empty($translatedValue) ? $optionLabel : $translatedValue;
+            }
+            $translatedValue = $defaultValue;
+        } elseif ($property === 'fluidAdditionalAttributes' && is_array($defaultValue)) {
+            foreach ($defaultValue as $propertyName => &$propertyValue) {
+                $translationKeyChain = [];
+                foreach ($translationFiles as $translationFile) {
+                    if (!empty($originalFormIdentifier)) {
+                        $translationKeyChain[] = sprintf(
+                            '%s:%s.element.%s.%s.%s',
+                            $translationFile,
+                            $originalFormIdentifier,
+                            $element['identifier'],
+                            $propertyType,
+                            $propertyName
+                        );
+                    }
+                    $translationKeyChain[] = sprintf(
+                        '%s:%s.element.%s.%s.%s',
+                        $translationFile,
+                        $formRuntime['identifier'],
+                        $element['identifier'],
+                        $propertyType,
+                        $propertyName
+                    );
+                    $translationKeyChain[] = sprintf(
+                        '%s:element.%s.%s.%s',
+                        $translationFile,
+                        $element['identifier'],
+                        $propertyType,
+                        $propertyName
+                    );
+                    $translationKeyChain[] = sprintf(
+                        '%s:element.%s.%s.%s',
+                        $translationFile,
+                        $element['type'],
+                        $propertyType,
+                        $propertyName
+                    );
+                }
+
+                $translatedValue = $this->processTranslationChain($translationKeyChain, $language, $arguments);
+                $propertyValue = empty($translatedValue) ? $propertyValue : $translatedValue;
+            }
+            $translatedValue = $defaultValue;
+        } else {
+            $translationKeyChain = [];
+            foreach ($translationFiles as $translationFile) {
+                if (!empty($originalFormIdentifier)) {
+                    $translationKeyChain[] = sprintf(
+                        '%s:%s.element.%s.%s.%s',
+                        $translationFile,
+                        $originalFormIdentifier,
+                        $element['identifier'],
+                        $propertyType,
+                        $property
+                    );
+                }
+                $translationKeyChain[] = sprintf(
+                    '%s:%s.element.%s.%s.%s',
+                    $translationFile,
+                    'identifier',
+                    $element['identifier'],
+                    $propertyType,
+                    $property
+                );
+                $translationKeyChain[] = sprintf(
+                    '%s:element.%s.%s.%s',
+                    $translationFile,
+                    $element['identifier'],
+                    $propertyType,
+                    $property
+                );
+                $translationKeyChain[] = sprintf(
+                    '%s:element.%s.%s.%s',
+                    $translationFile,
+                    $element['type'],
+                    $propertyType,
+                    $property
+                );
+            }
+
+            $translatedValue = $this->processTranslationChain($translationKeyChain, $language, $arguments);
+            $translatedValue = empty($translatedValue) ? $defaultValue : $translatedValue;
+        }
+
+        return $translatedValue;
+    }
+
+    /**
+     * @param array<string,mixed> $element
+     * @param int $code
+     * @param array<string,mixed> $formRuntime
+     * @param array<string,mixed> $arguments
+     * @param string $defaultValue
+     * @return string
+     */
+    public function translateElementError(
+        array $element,
+        int $code,
+        array $formRuntime,
+        array $arguments = [],
+        string $defaultValue = ''
+    ): string {
+        if (empty($code)) {
+            throw new InvalidArgumentException('The argument "code" is empty', 1489272978);
+        }
+
+        $renderingOptions = $element['renderingOptions'];
+        $translationFiles = $renderingOptions['translation']['translationFiles'] ?? [];
+        if (empty($translationFiles)) {
+            $translationFiles = $formRuntime['renderingOptions']['translation']['translationFiles'];
+        }
+
+        $translationFiles = $this->sortArrayWithIntegerKeysDescending($translationFiles);
+        $language = $renderingOptions['language'] ?? null;
+        $originalFormIdentifier = $formRuntime['renderingOptions']['_originalIdentifier'] ?? null;
+
+        $translationKeyChain = [];
+        foreach ($translationFiles as $translationFile) {
+            if (!empty($originalFormIdentifier)) {
+                $translationKeyChain[] = sprintf(
+                    '%s:%s.validation.error.%s.%s',
+                    $translationFile,
+                    $originalFormIdentifier,
+                    $element['identifier'],
+                    $code
+                );
+
+                $translationKeyChain[] = sprintf(
+                    '%s:%s.validation.error.%s',
+                    $translationFile,
+                    $originalFormIdentifier,
+                    $code
+                );
+            }
+            $translationKeyChain[] = sprintf(
+                '%s:%s.validation.error.%s.%s',
+                $translationFile,
+                $formRuntime['identifier'],
+                $element['identifier'],
+                $code
+            );
+            $translationKeyChain[] = sprintf(
+                '%s:%s.validation.error.%s',
+                $translationFile,
+                $formRuntime['identifier'],
+                $code
+            );
+            $translationKeyChain[] = sprintf(
+                '%s:validation.error.%s.%s',
+                $translationFile,
+                $element['identifier'],
+                $code
+            );
+            $translationKeyChain[] = sprintf('%s:validation.error.%s', $translationFile, $code);
+        }
+
+        $translatedValue = $this->processTranslationChain($translationKeyChain, $language, $arguments);
+
+        return empty($translatedValue) ? $defaultValue : $translatedValue;
+    }
+}

--- a/Classes/Form/Translator.php
+++ b/Classes/Form/Translator.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+namespace FriendsOfTYPO3\Headless\Form;
+
+use function array_keys;
+use function array_merge;
+use function array_replace_recursive;
+use FriendsOfTYPO3\Headless\Form\Service\FormTranslationService;
+use function is_array;
+
+final class Translator
+{
+    protected static function getTranslationService(): FormTranslationService
+    {
+        return FormTranslationService::getInstance();
+    }
+
+    /**
+     * @param array<mixed> $formDefinition
+     * @param array<mixed> $renderingOptions
+     * @return array<mixed>
+     */
+    public function translate(array $formDefinition, array $renderingOptions): array
+    {
+        $result['renderables'] = [];
+        $formRuntime = [
+            'identifier' => $formDefinition['identifier'],
+            'renderingOptions' => $renderingOptions,
+        ];
+
+        if (isset($formDefinition['i18n']['properties'])) {
+            foreach ($formDefinition['i18n']['properties'] as $prop => $value) {
+                $formDefinition['i18n']['properties'][$prop] = self::getTranslationService()
+                    ->translateElementValue($formDefinition['i18n'], [$prop], $formRuntime);
+            }
+        }
+
+        foreach ($formDefinition['renderables'] as $page) {
+            $pageTranslation = [
+                'label' => self::getTranslationService()->translateElementValue($page, ['label'], $formRuntime),
+            ];
+
+            if (!isset($page['renderables']) || !is_array($page['renderables'])) {
+                continue;
+            }
+
+            foreach ($page['renderables'] as &$element) {
+                $properties = [];
+
+                if (isset($element['validators']) &&
+                    is_array($element['validators'])) {
+                    foreach ($element['validators'] as &$validator) {
+                        if (!isset($validator['errorMessage'])) {
+                            continue;
+                        }
+
+                        $validator['errorMessage'] = self::getTranslationService()->translateElementError(
+                            $element,
+                            $validator['errorMessage'],
+                            $formRuntime,
+                            is_array($validator['options']) ? $validator['options'] : []
+                        );
+                    }
+                }
+
+                foreach (array_keys($element['properties']) as $property
+                ) {
+                    $properties[$property] = self::getTranslationService()->translateElementValue(
+                        $element,
+                        [$property],
+                        $formRuntime
+                    );
+                }
+
+                if (isset($element['properties']['validationErrorMessages']) &&
+                    is_array($element['properties']['validationErrorMessages'])) {
+                    $properties['validationErrorMessages'] = [];
+                    foreach ($element['properties']['validationErrorMessages'] as $error) {
+                        $properties['validationErrorMessages'][] = [
+                            'code' => $error['code'],
+                            'message' => self::getTranslationService()->translateElementError(
+                                $element,
+                                $error['code'],
+                                $formRuntime
+                            ),
+                        ];
+                    }
+                }
+
+                $translatedDefaultValue = self::getTranslationService()->translateElementValue(
+                    $element,
+                    ['defaultValue'],
+                    $formRuntime
+                );
+
+                $pageTranslation['renderables'][] = [
+                    'label' => self::getTranslationService()->translateElementValue(
+                        $element,
+                        ['label'],
+                        $formRuntime
+                    ),
+                    'defaultValue' => $translatedDefaultValue ?: $element['defaultValue'],
+                    'properties' => $properties,
+                ];
+            }
+
+            $result['renderables'][] = array_replace_recursive($page, $pageTranslation);
+        }
+
+        return array_merge($formDefinition, $result);
+    }
+}

--- a/Classes/XClass/Controller/FormFrontendController.php
+++ b/Classes/XClass/Controller/FormFrontendController.php
@@ -1,0 +1,235 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\XClass\Controller;
+
+use FriendsOfTYPO3\Headless\Form\CustomOptionsInterface;
+use FriendsOfTYPO3\Headless\Form\Decorator\DefinitionDecoratorInterface;
+use FriendsOfTYPO3\Headless\Form\Decorator\FormDefinitionDecorator;
+use FriendsOfTYPO3\Headless\Form\Translator;
+use FriendsOfTYPO3\Headless\XClass\FormRuntime;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Mvc\Web\Response;
+use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
+use TYPO3\CMS\Form\Domain\Factory\ArrayFormFactory;
+
+/**
+ * The frontend controller
+ *
+ * Scope: frontend
+ * @internal
+ */
+class FormFrontendController extends \TYPO3\CMS\Form\Controller\FormFrontendController
+{
+    private $jsonFormTranslator;
+
+    public function __construct()
+    {
+        $this->hashService = GeneralUtility::makeInstance(HashService::class);
+        $this->jsonFormTranslator = GeneralUtility::makeInstance(Translator::class);
+    }
+
+    /**
+     * Take the form which should be rendered from the plugin settings
+     * and overlay the formDefinition with additional data from
+     * flexform and typoscript settings.
+     * This method is used directly to display the first page from the
+     * formDefinition because its cached.
+     *
+     * @internal
+     */
+    public function renderAction(): void
+    {
+        $formDefinition = [];
+        if (!empty($this->settings['persistenceIdentifier'])) {
+            $formDefinition = $this->formPersistenceManager->load($this->settings['persistenceIdentifier']);
+            $formDefinition['persistenceIdentifier'] = $this->settings['persistenceIdentifier'];
+            $formDefinition = $this->overrideByTypoScriptSettings($formDefinition);
+            $formDefinition = $this->overrideByFlexFormSettings($formDefinition);
+            $formDefinition = ArrayUtility::setValueByPath(
+                $formDefinition,
+                'renderingOptions._originalIdentifier',
+                $formDefinition['identifier'],
+                '.'
+            );
+
+            $formId = ($this->configurationManager->getContentObject() !== null ?
+                ($this->configurationManager->getContentObject()->data['uid'] ?? 0) : 0);
+
+            $formDefinition['identifier'] .= '-' . $formId;
+        }
+
+        $i18n = [];
+
+        if (isset($formDefinition['i18n'])) {
+            $i18n = $formDefinition['i18n'] ?? [];
+            unset($formDefinition['i18n']);
+        }
+
+        $decoratorClass = null;
+
+        if (isset($formDefinition['renderingOptions']['formDecorator'])) {
+            $decoratorClass = $formDefinition['renderingOptions']['formDecorator'];
+            unset($formDefinition['renderingOptions']['formDecorator']);
+        }
+
+        if (empty($decoratorClass)) {
+            $decoratorClass = FormDefinitionDecorator::class;
+        }
+
+        $prototypeName = $formDefinition['prototypeName'] ?? 'standard';
+        $factory = $this->objectManager->get(ArrayFormFactory::class);
+        $formDefinitionObj = $factory->build($formDefinition, $prototypeName);
+        $response = $this->controllerContext->getResponse() ?? $this->objectManager->get(Response::class);
+        /**
+          * @var FormRuntime $formRuntime
+         */
+        $formRuntime = $formDefinitionObj->bind($this->controllerContext->getRequest(), $response);
+        $formState = $formRuntime->getFormState();
+        $finisherResponse = $formRuntime->run();
+
+        $elements = $formRuntime->getFormDefinition()->getElements();
+        $honeyPot = null;
+
+        if (isset($formRuntime->getFormDefinition()->getRenderingOptions()['honeypot']['enable']) &&
+            $formRuntime->getFormDefinition()->getRenderingOptions()['honeypot']['enable'] === true) {
+            $honeyPot = array_pop($elements);
+        }
+
+        $stateHash = $this->hashService->appendHmac(base64_encode(serialize($formState)));
+        $formFieldsNames = [];
+
+        $currentPageIndex = $formRuntime->getCurrentPage() ? $formRuntime->getCurrentPage()->getIndex() : 0;
+        $currentPageId = $currentPageIndex + 1;
+        $formFields = $formDefinition['renderables'][$currentPageIndex]['renderables'];
+
+        // provides support for custom options providers (dynamic selects/radio/checkboxes)
+        foreach ($formFields as &$field) {
+            if (!empty($field['properties']['customOptions'])) {
+                $customOptions = GeneralUtility::makeInstance($field['properties']['customOptions']);
+
+                if ($customOptions instanceof CustomOptionsInterface) {
+                    $field['properties']['options'] = $customOptions->get();
+                }
+
+                unset($field['properties']['customOptions']);
+            }
+
+            // phpcs:ignore Generic.Files.LineLength
+            $formFieldsNames[] = 'tx_form_formframework[' . $formDefinition['identifier'] . '][' . $field['identifier'] . ']';
+        }
+
+        unset($field);
+
+        if ($honeyPot) {
+            $formFields[] = [
+                'properties' => $honeyPot->getProperties(),
+                'type' => $honeyPot->getType(),
+                'identifier' => $honeyPot->getIdentifier(),
+            ];
+            $formFieldsNames[] = 'tx_form_formframework[' . $formDefinition['identifier'] . '][' . $honeyPot->getIdentifier() . ']';
+        }
+
+        $formFields[] = [
+            'properties' => [],
+            'type' => 'Hidden',
+            'identifier' => '__currentPage',
+            'defaultValue' => $currentPageId,
+        ];
+
+        $formFieldsNames[] = 'tx_form_formframework[' . $formDefinition['identifier'] . '][__currentPage]';
+        $requestHash = $this->mvcPropertyMappingConfigurationService->generateTrustedPropertiesToken(
+            $formFieldsNames,
+            'tx_form_formframework'
+        );
+
+        $formFields[] = [
+            'properties' => [],
+            'type' => 'Hidden',
+            'identifier' => '__trustedProperties',
+            'defaultValue' => $requestHash,
+        ];
+
+        $formFields[] = [
+            'properties' => [],
+            'type' => 'Hidden',
+            'identifier' => '__state',
+            'defaultValue' => $stateHash,
+        ];
+
+        $formDefinition['renderables'][$currentPageIndex]['renderables'] = $formFields;
+
+        $formDefinition['i18n'] = $i18n;
+        $formDefinition = $this->jsonFormTranslator->translate(
+            $formDefinition,
+            $formRuntime->getFormDefinition()->getRenderingOptions()
+        );
+
+        $formStatus['status'] = null;
+        $formStatus['errors'] = null;
+        $formStatus['actionAfterSuccess'] = $finisherResponse ? json_decode($finisherResponse) : null;
+        $formStatus['page'] = [
+            'current' => $currentPageIndex,
+            'nextPage' => $this->getNextPage($formRuntime),
+            'pages' => \count($formRuntime->getPages()),
+        ];
+
+        if ($formState &&
+            $formState->isFormSubmitted() &&
+            $this->getControllerContext()->getRequest()->getMethod() === 'POST') {
+            $result = $formRuntime->getRequest()->getOriginalRequestMappingResults();
+            /**
+             * @var array<string,\TYPO3\CMS\Extbase\Error\Error[]>
+             */
+            $errors = $result->getFlattenedErrors();
+            $formStatus['status'] = $result->hasErrors() ? 'failure' : 'success';
+            $formStatus['errors'] = $this->prepareErrors($errors, $formDefinition['identifier']);
+        }
+
+        /**
+         * @var DefinitionDecoratorInterface $definitionDecorator
+         */
+        $definitionDecorator = GeneralUtility::makeInstance($decoratorClass);
+
+        $this->view->assignMultiple([
+            'formConfiguration' => $definitionDecorator($formDefinition, $currentPageIndex),
+            'formStatus' => $formStatus
+        ]);
+    }
+
+    /**
+     * @param array<string,\TYPO3\CMS\Extbase\Error\Error[]> $errors
+     * @param string $formIdentifier
+     * @return array<string, string>|null
+     */
+    private function prepareErrors(array $errors, string $formIdentifier): ?array
+    {
+        $parsedErrors = [];
+
+        foreach ($errors as $key => $errorObj) {
+            $parsedErrors[str_replace($formIdentifier . '.', '', $key)] = $errorObj[0]->getMessage();
+        }
+
+        return \count($parsedErrors) ? $parsedErrors : null;
+    }
+
+    private function getNextPage(\TYPO3\CMS\Form\Domain\Runtime\FormRuntime $formRuntime): ?int
+    {
+        if ($formRuntime->getCurrentPage() && $formRuntime->getNextEnabledPage()) {
+            return $formRuntime->getNextEnabledPage()->getIndex();
+        }
+
+        return null;
+    }
+}

--- a/Classes/XClass/FormRuntime.php
+++ b/Classes/XClass/FormRuntime.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\XClass;
+
+class FormRuntime extends \TYPO3\CMS\Form\Domain\Runtime\FormRuntime
+{
+    /**
+     * Stripped "render" method
+     * Does not render html form & handles finishers & variants
+     *
+     * @return string|null finisher response or null
+     */
+    public function run(): ?string
+    {
+        if ($this->isAfterLastPage()) {
+            return $this->invokeFinishers();
+        }
+        $this->processVariants();
+
+        $this->formState->setLastDisplayedPageIndex($this->currentPage->getIndex());
+
+        return null;
+    }
+}

--- a/Configuration/TypoScript/Configuration/Form.typoscript
+++ b/Configuration/TypoScript/Configuration/Form.typoscript
@@ -1,0 +1,7 @@
+plugin.tx_form {
+    view {
+        templateRootPaths = EXT:headless/Resources/Private/Form/Templates/
+        partialRootPaths = EXT:headless/Resources/Private/Form/Partials/
+        layoutRootPaths = EXT:headless/Resources/Private/Form/Layouts/
+    }
+}

--- a/Configuration/TypoScript/ContentElement/Form.typoscript
+++ b/Configuration/TypoScript/ContentElement/Form.typoscript
@@ -1,0 +1,34 @@
+tt_content.form_formframework =< lib.contentElement
+tt_content.form_formframework {
+    fields {
+        content {
+            fields {
+                link = TEXT
+                link {
+                    field = pid
+                    htmlSpecialChars = 1
+                    typolink {
+                        parameter {
+                            field = pid
+                        }
+                        additionalParams = &tx_form_formframework[action]=perform&tx_form_formframework[controller]=FormFrontend
+                        returnLast = url
+                    }
+                }
+
+                form = USER_INT
+                form {
+                    userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
+                    vendorName = TYPO3\CMS
+                    extensionName = Form
+                    pluginName = Formframework
+                    controller = FormFrontend
+
+                    view < plugin.tx_form.view
+                    persistence < plugin.tx_form.persistence
+                    settings < plugin.tx_form.settings
+                }
+            }
+        }
+    }
+}

--- a/Resources/Private/Form/Templates/Form.html
+++ b/Resources/Private/Form/Templates/Form.html
@@ -1,0 +1,14 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:formvh="http://typo3.org/ns/TYPO3/CMS/Form/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:spaceless>
+    <f:format.raw>
+        <f:format.json value="{
+                action: form.renderingOptions.controllerAction,
+                method: form.renderingOptions.httpMethod,
+                enctype: form.renderingOptions.httpEnctype,
+                addQueryString: form.renderingOptions.addQueryString,
+                argumentsToBeExcludedFromQueryString: form.renderingOptions.argumentsToBeExcludedFromQueryString,
+                additionalParams: form.renderingOptions.additionalParams
+		}"/>
+    </f:format.raw>
+</f:spaceless>
+</html>

--- a/Resources/Private/Form/Templates/Render.html
+++ b/Resources/Private/Form/Templates/Render.html
@@ -1,0 +1,12 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:formvh="http://typo3.org/ns/TYPO3/CMS/Form/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:spaceless>
+    <f:format.raw>
+        <f:format.json value="{
+                id: formConfiguration.identifier,
+                api: formStatus,
+                i18n: formConfiguration.i18n,
+                elements: formConfiguration.elements
+		}"/>
+    </f:format.raw>
+</f:spaceless>
+</html>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -12,7 +12,7 @@
 defined('TYPO3_MODE') || die();
 
 call_user_func(
-    function () {
+    static function () {
         if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['FrontendBaseUrlInPagePreview'])) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['FrontendBaseUrlInPagePreview'] = false;
         }
@@ -35,6 +35,16 @@ call_user_func(
         if (\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\Features::class)->isFeatureEnabled('FrontendBaseUrlInPagePreview')) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TYPO3\CMS\Viewpage\Controller\ViewModuleController::class] = [
                 'className' => FriendsOfTYPO3\Headless\XClass\Controller\ViewModuleController::class
+            ];
+        }
+
+        if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('form')) {
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Form\Controller\FormFrontendController::class] = [
+                'className' => FriendsOfTYPO3\Headless\XClass\Controller\FormFrontendController::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Form\Domain\Runtime\FormRuntime::class] = [
+                'className' => FriendsOfTYPO3\Headless\XClass\FormRuntime::class
             ];
         }
 


### PR DESCRIPTION
Resolves #79 and:
- add support of core translation of form labels etc (translated same way as fluid form)
- pagination of form (pages/tabs)
- support of custom options (i.e. from database) in selects
- add custom finisher for redirect for headless API
- add form response decorator and API to customize per project
