### PR TITLE
[FEATURE] introduce RootSiteProcessor

### DIFF
--- a/Classes/DataProcessing/RootSiteProcessing/DomainSchema.php
+++ b/Classes/DataProcessing/RootSiteProcessing/DomainSchema.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use function is_array;
 use function str_replace;
 
-class DomainSchema implements SiteSchemaInterface
+final class DomainSchema implements SiteSchemaInterface
 {
     /**
      * @var SiteService
@@ -72,7 +72,7 @@ class DomainSchema implements SiteSchemaInterface
             ];
 
             // process if necessary
-            if (!empty($processorConfiguration['dataProcessing.']) &&
+            if (isset($processorConfiguration['dataProcessing.']) &&
                 is_array($processorConfiguration['dataProcessing.'])) {
                 $domain = $this->processAdditionalDataProcessors(
                     $domain,

--- a/Classes/DataProcessing/RootSiteProcessing/DomainSchema.php
+++ b/Classes/DataProcessing/RootSiteProcessing/DomainSchema.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing;
+
+use FriendsOfTYPO3\Headless\Service\SiteService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentDataProcessor;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+use function is_array;
+use function str_replace;
+
+class DomainSchema implements SiteSchemaInterface
+{
+    /**
+     * @var SiteService
+     */
+    private $siteService;
+    /**
+     * @var ContentDataProcessor
+     */
+    private $contentDataProcessor;
+
+    public function __construct(SiteService $service = null, ContentDataProcessor $contentObjectRenderer = null)
+    {
+        $this->siteService = $service ?? GeneralUtility::makeInstance(SiteService::class);
+        $this->contentDataProcessor = $contentObjectRenderer ??
+            GeneralUtility::makeInstance(ContentDataProcessor::class);
+    }
+
+    /**
+     * @param SiteProviderInterface $provider
+     * @param array<string, mixed> $options
+     * @return array<int, array<string, mixed>>
+     */
+    public function process(SiteProviderInterface $provider, array $options = []): array
+    {
+        $processorConfiguration = $options['processorConfiguration'] ?? [];
+        $cObj = $options['cObj'] ?? GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $result = [];
+
+        foreach ($provider->getSites() as $site) {
+            $protocol = $site->getBase()->getScheme() . '://';
+            $baseUrl = $protocol . $site->getBase()->getHost();
+            $url = $this->siteService->getFrontendUrl($baseUrl, $site->getRootPageId());
+
+            $locales = [];
+
+            foreach ($site->getLanguages() as $language) {
+                $locales[] = $language->getTypo3Language();
+            }
+
+            $domain = [
+                'name' => str_replace($protocol, '', $url),
+                'baseURL' => $url,
+                'api' => ['baseURL' => $baseUrl],
+                'i18n' => [
+                    'locales' => $locales,
+                    'defaultLocale' => $site->getDefaultLanguage()->getTypo3Language()
+                ],
+            ];
+
+            // process if necessary
+            if (!empty($processorConfiguration['dataProcessing.']) &&
+                is_array($processorConfiguration['dataProcessing.'])) {
+                $domain = $this->processAdditionalDataProcessors(
+                    $domain,
+                    $cObj,
+                    $processorConfiguration
+                );
+            }
+
+            $result[] = $domain;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Process additional data processors
+     *
+     * @param array<string, mixed> $page
+     * @param ContentObjectRenderer $cObj
+     * @param array<string, mixed> $processorConfiguration
+     * @return array<string, mixed>
+     */
+    protected function processAdditionalDataProcessors(
+        array $page,
+        ContentObjectRenderer $cObj,
+        array $processorConfiguration
+    ): array {
+        $cObj->start($page, 'pages');
+        return $this->contentDataProcessor->process($cObj, $processorConfiguration, $page);
+    }
+}

--- a/Classes/DataProcessing/RootSiteProcessing/SiteProvider.php
+++ b/Classes/DataProcessing/RootSiteProcessing/SiteProvider.php
@@ -26,7 +26,7 @@ use function count;
 use function in_array;
 use function usort;
 
-class SiteProvider implements SiteProviderInterface
+final class SiteProvider implements SiteProviderInterface
 {
     /**
      * @var ConnectionPool

--- a/Classes/DataProcessing/RootSiteProcessing/SiteProvider.php
+++ b/Classes/DataProcessing/RootSiteProcessing/SiteProvider.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing;
+
+use Doctrine\DBAL\Driver\Result;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function array_map;
+use function array_values;
+use function count;
+use function in_array;
+use function usort;
+
+class SiteProvider implements SiteProviderInterface
+{
+    /**
+     * @var ConnectionPool
+     */
+    private $connectionPool;
+    /**
+     * @var SiteFinder
+     */
+    private $siteFinder;
+    /**
+     * @var Site[]
+     */
+    private $sites;
+    /**
+     * @var array[]
+     */
+    private $pagesData;
+    /**
+     * @var Site
+     */
+    private $currentRootPage;
+
+    public function __construct(ConnectionPool $connectionPool = null, SiteFinder $siteFinder = null)
+    {
+        $this->connectionPool = $connectionPool ?? GeneralUtility::makeInstance(ConnectionPool::class);
+        $this->siteFinder = $siteFinder ?? GeneralUtility::makeInstance(SiteFinder::class);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @param int $siteUid
+     */
+    public function prepare(array $config, int $siteUid): self
+    {
+        $allowedSites = $config['allowedSites'] ?? null;
+        $sortingField = $config['sortingField'] ?? 'sorting';
+        $customSorting = $config['sortingImplementation'] ?? null;
+
+        if ($sortingField === '') {
+            $sortingField = 'sorting';
+        }
+
+        if ($allowedSites === null) {
+            $allowedSites = [];
+        } else {
+            $allowedSites = GeneralUtility::intExplode(',', $allowedSites, true);
+        }
+
+        $sitesFromPid = (int)($config['sitesFromPid'] ?? 0);
+
+        if ($sitesFromPid) {
+            $allowedSites = $this->fetchAvailableRootSitesByPid($sitesFromPid);
+        }
+
+        $sites = $this->filterSites($allowedSites);
+        $pages = $this->fetchPageData($sites, $config);
+
+        if ($customSorting !== null) {
+            if (!\is_a($customSorting, SiteSortingInterface::class, true)) {
+                throw new \InvalidArgumentException('Invalid implementation of SiteSortingInterface');
+            }
+            /**
+             * @var SiteSortingInterface $sorting
+             */
+            $sorting = GeneralUtility::makeInstance($customSorting, $sites, $pages, $sortingField);
+            $sites = $sorting->sort();
+        } else {
+            usort($sites, static function (Site $siteA, Site $siteB) use ($pages, $sortingField) {
+                // phpcs:ignore Generic.Files.LineLength
+                return (int)$pages[$siteA->getRootPageId()][$sortingField] >= (int)$pages[$siteB->getRootPageId()][$sortingField] ? 1 : -1;
+            });
+        }
+
+        $this->sites = $sites;
+        $this->pagesData = $pages;
+        $this->currentRootPage = $this->siteFinder->getSiteByPageId($siteUid);
+
+        return $this;
+    }
+
+    /**
+     * @return array<Site>
+     */
+    public function getSites(): array
+    {
+        return $this->sites;
+    }
+
+    /**
+     * @return array<int, array>
+     */
+    public function getPages(): array
+    {
+        return $this->pagesData;
+    }
+
+    /**
+     * @return Site
+     */
+    public function getCurrentRootPage(): Site
+    {
+        return $this->currentRootPage;
+    }
+
+    /**
+     * @param array<int> $allowedSites
+     * @return array<Site>
+     */
+    private function filterSites(array $allowedSites = []): array
+    {
+        $allSites = $this->siteFinder->getAllSites();
+
+        if (count($allowedSites) === 0) {
+            return $allSites;
+        }
+
+        $sites = [];
+
+        foreach ($allSites as $site) {
+            if (in_array($site->getRootPageId(), $allowedSites, true)) {
+                $sites[] = $site;
+            }
+        }
+
+        return $sites;
+    }
+
+    /**
+     * @param int $pid
+     * @return array<int>
+     * @throws \Doctrine\DBAL\Driver\Exception
+     */
+    private function fetchAvailableRootSitesByPid(int $pid): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+
+        $stmt = $queryBuilder
+            ->select('uid')
+            ->from('pages')
+            ->where('is_siteroot = 1')
+            ->andWhere('hidden = 0')
+            ->andWhere('deleted = 0')
+            ->andWhere('pid = ' . $queryBuilder->createNamedParameter($pid, \PDO::PARAM_INT))
+            ->execute();
+
+        $pagesData = [];
+
+        if ($stmt instanceof Result) {
+            $pagesData = $stmt->fetchAllAssociative();
+        }
+
+        return array_map(static function (array $item): int {
+            return (int)$item['uid'];
+        }, $pagesData);
+    }
+
+    /**
+     * Fetches pages' titles & translations (if site has more than one language) of root pages
+     *
+     * @param array<Site> $sites
+     * @param array<string, mixed> $config
+     * @return array<int, array>
+     * @throws \Doctrine\DBAL\Driver\Exception
+     */
+    private function fetchPageData(array $sites, array $config = []): array
+    {
+        $rootPagesId = array_values(array_map(static function (Site $item) {
+            return $item->getRootPageId();
+        }, $sites));
+
+        $columns = GeneralUtility::trimExplode(',', $config['dbColumns'] ?? 'uid,title,sorting', true);
+
+        if (count($columns) === 0) {
+            $columns = ['uid', 'title', 'sorting'];
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+
+        $pagesData = [];
+        $stmt = $queryBuilder
+            ->select(...$columns)
+            ->from('pages')
+            ->where('uid IN (' . $queryBuilder->createNamedParameter($rootPagesId, Connection::PARAM_INT_ARRAY) . ')')
+            ->execute();
+
+        if ($stmt instanceof Result) {
+            $pagesData = $stmt->fetchAllAssociative();
+        }
+
+        $pages = [];
+
+        foreach ($pagesData as $page) {
+            $pages[(int)$page['uid']] = $page;
+        }
+
+        return $pages;
+    }
+}

--- a/Classes/DataProcessing/RootSiteProcessing/SiteProviderInterface.php
+++ b/Classes/DataProcessing/RootSiteProcessing/SiteProviderInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing;
+
+use TYPO3\CMS\Core\Site\Entity\Site;
+
+interface SiteProviderInterface
+{
+    /**
+     * @param array<string, mixed> $config
+     * @param int $siteUid
+     */
+    public function prepare(array $config, int $siteUid);
+
+    /**
+     * @return array<Site>
+     */
+    public function getSites(): array;
+
+    /**
+     * @return array<int, array>
+     */
+    public function getPages(): array;
+
+    /**
+     * @return Site
+     */
+    public function getCurrentRootPage(): Site;
+}

--- a/Classes/DataProcessing/RootSiteProcessing/SiteSchema.php
+++ b/Classes/DataProcessing/RootSiteProcessing/SiteSchema.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing;
+
+use FriendsOfTYPO3\Headless\Service\SiteService;
+use InvalidArgumentException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentDataProcessor;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+use function is_array;
+use function trim;
+
+class SiteSchema implements SiteSchemaInterface
+{
+    /**
+     * @var SiteService
+     */
+    private $siteService;
+    /**
+     * @var ContentDataProcessor
+     */
+    private $contentDataProcessor;
+
+    public function __construct(SiteService $service = null, ContentDataProcessor $contentObjectRenderer = null)
+    {
+        $this->siteService = $service ?? GeneralUtility::makeInstance(SiteService::class);
+        $this->contentDataProcessor = $contentObjectRenderer ??
+            GeneralUtility::makeInstance(ContentDataProcessor::class);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<int, array<string, mixed>>
+     */
+    public function process(SiteProviderInterface $provider, array $options = []): array
+    {
+        $processorConfiguration = $options['processorConfiguration'] ?? [];
+        $siteUid = (int)($options['siteUid'] ?? 0);
+        $titleField = ($processorConfiguration['titleField'] ?? 'title');
+
+        if (trim($titleField) === '') {
+            throw new InvalidArgumentException('Invalid title field');
+        }
+
+        $cObj = $options['cObj'] ?? GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $result = [];
+        $pages = $provider->getPages();
+
+        foreach ($provider->getSites() as $site) {
+            $current = 0;
+            $active = 0;
+            $spacer = 0;
+            $baseUrl = $site->getBase()->getScheme() . '://' . $site->getBase()->getHost();
+            $url = $this->siteService->getFrontendUrl($baseUrl, $site->getRootPageId());
+
+            if ($provider->getCurrentRootPage() === $site) {
+                $active = 1;
+                if ($site->getRootPageId() === $siteUid) {
+                    $current = 1;
+                }
+            }
+
+            $pageInfo = $pages[$site->getRootPageId()];
+
+            $page = [
+                'title' => $pageInfo[$titleField],
+                'link' => $url,
+                'active' => $active,
+                'current' => $current,
+                'spacer' => $spacer,
+            ];
+
+            // process page if necessary
+            if (!empty($processorConfiguration['dataProcessing.']) &&
+                is_array($processorConfiguration['dataProcessing.'])) {
+                $page = $this->processAdditionalDataProcessors(
+                    $page,
+                    $cObj,
+                    $processorConfiguration
+                );
+            }
+
+            $result[] = $page;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Process additional data processors
+     *
+     * @param array<string, mixed> $page
+     * @param ContentObjectRenderer $cObj
+     * @param array<string, mixed> $processorConfiguration
+     * @return array<string, mixed>
+     */
+    protected function processAdditionalDataProcessors(
+        $page,
+        ContentObjectRenderer $cObj,
+        $processorConfiguration
+    ): array {
+        $cObj->start($page, 'pages');
+        return $this->contentDataProcessor->process($cObj, $processorConfiguration, $page);
+    }
+}

--- a/Classes/DataProcessing/RootSiteProcessing/SiteSchema.php
+++ b/Classes/DataProcessing/RootSiteProcessing/SiteSchema.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing;
 
 use FriendsOfTYPO3\Headless\Service\SiteService;
-use InvalidArgumentException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentDataProcessor;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -22,7 +21,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use function is_array;
 use function trim;
 
-class SiteSchema implements SiteSchemaInterface
+final class SiteSchema implements SiteSchemaInterface
 {
     /**
      * @var SiteService
@@ -48,10 +47,10 @@ class SiteSchema implements SiteSchemaInterface
     {
         $processorConfiguration = $options['processorConfiguration'] ?? [];
         $siteUid = (int)($options['siteUid'] ?? 0);
-        $titleField = ($processorConfiguration['titleField'] ?? 'title');
+        $titleField = $processorConfiguration['titleField'] ?? 'title';
 
         if (trim($titleField) === '') {
-            throw new InvalidArgumentException('Invalid title field');
+            $titleField = 'title';
         }
 
         $cObj = $options['cObj'] ?? GeneralUtility::makeInstance(ContentObjectRenderer::class);
@@ -83,7 +82,7 @@ class SiteSchema implements SiteSchemaInterface
             ];
 
             // process page if necessary
-            if (!empty($processorConfiguration['dataProcessing.']) &&
+            if (isset($processorConfiguration['dataProcessing.']) &&
                 is_array($processorConfiguration['dataProcessing.'])) {
                 $page = $this->processAdditionalDataProcessors(
                     $page,

--- a/Classes/DataProcessing/RootSiteProcessing/SiteSchemaInterface.php
+++ b/Classes/DataProcessing/RootSiteProcessing/SiteSchemaInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing;
+
+interface SiteSchemaInterface
+{
+    /**
+     * @param array<string, mixed> $options
+     * @return array<int, array<string, mixed>>
+     */
+    public function process(SiteProviderInterface $provider, array $options = []): array;
+}

--- a/Classes/DataProcessing/RootSiteProcessing/SiteSortingInterface.php
+++ b/Classes/DataProcessing/RootSiteProcessing/SiteSortingInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing;
+
+use TYPO3\CMS\Core\Site\Entity\Site;
+
+interface SiteSortingInterface
+{
+    /**
+     * @param array<Site> $sites
+     * @param array<int, array<mixed>> $pages
+     * @param string $sortingField
+     */
+    public function __construct(array $sites, array $pages, string $sortingField);
+
+    /**
+     * @return array<Site>
+     */
+    public function sort(): array;
+}

--- a/Classes/DataProcessing/RootSiteProcessing/SiteSortingInterface.php
+++ b/Classes/DataProcessing/RootSiteProcessing/SiteSortingInterface.php
@@ -18,13 +18,6 @@ use TYPO3\CMS\Core\Site\Entity\Site;
 interface SiteSortingInterface
 {
     /**
-     * @param array<Site> $sites
-     * @param array<int, array<mixed>> $pages
-     * @param string $sortingField
-     */
-    public function __construct(array $sites, array $pages, string $sortingField);
-
-    /**
      * @return array<Site>
      */
     public function sort(): array;

--- a/Classes/DataProcessing/RootSitesProcessor.php
+++ b/Classes/DataProcessing/RootSitesProcessor.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2020
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\DataProcessing;
+
+use FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\SiteProvider;
+use FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\SiteProviderInterface;
+use FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\SiteSchema;
+use FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\SiteSchemaInterface;
+use InvalidArgumentException;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentDataProcessor;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
+
+class RootSitesProcessor implements DataProcessorInterface
+{
+    /**
+     * @var ContentDataProcessor
+     */
+    private $contentDataProcessor;
+
+    /**
+     * @param ContentObjectRenderer $cObj
+     * @param array<string,mixed> $contentObjectConfiguration
+     * @param array<string,mixed> $processorConfiguration
+     * @param array<string,mixed> $processedData
+     * @return array<string,mixed>
+     * @throws SiteNotFoundException
+     */
+    public function process(
+        ContentObjectRenderer $cObj,
+        array $contentObjectConfiguration,
+        array $processorConfiguration,
+        array $processedData
+    ): array {
+        $siteUid = $cObj->data['uid'];
+
+        if ($siteUid === null) {
+            return $processedData;
+        }
+
+        $this->contentDataProcessor = GeneralUtility::makeInstance(ContentDataProcessor::class);
+
+        $siteProviderClass = $processorConfiguration['siteProvider'] ?? SiteProvider::class;
+        $siteSchemaClass = $processorConfiguration['siteSchema'] ?? SiteSchema::class;
+
+        if (!\is_a($siteProviderClass, SiteProviderInterface::class, true)) {
+            // phpcs:ignore Generic.Files.LineLength
+            throw new InvalidArgumentException('Invalid siteProvider implementation! Please provide class with FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\SiteProviderInterface implemented!');
+        }
+
+        if (!\is_a($siteSchemaClass, SiteSchemaInterface::class, true)) {
+            // phpcs:ignore Generic.Files.LineLength
+            throw new InvalidArgumentException('Invalid SiteSchema implementation! Please provide class with FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\SiteSchemaInterface implemented!');
+        }
+
+        /**
+         * @var SiteProviderInterface $siteProvider
+         */
+        $siteProvider = GeneralUtility::makeInstance($siteProviderClass);
+        $siteProvider->prepare($processorConfiguration, $siteUid);
+
+        /**
+         * @var SiteSchemaInterface $siteSchema
+         */
+        $siteSchema = GeneralUtility::makeInstance($siteSchemaClass);
+
+        $targetVariableName = $cObj->stdWrapValue('as', $processorConfiguration, 'sites');
+        $processedData[$targetVariableName] = $siteSchema->process($siteProvider, [
+            'processorConfiguration' => $processorConfiguration,
+            'siteUid' => $siteUid,
+            'cObj' => $cObj
+        ]);
+
+        return $processedData;
+    }
+}

--- a/Configuration/TypoScript/Configuration/Domains.typoscript
+++ b/Configuration/TypoScript/Configuration/Domains.typoscript
@@ -1,0 +1,32 @@
+headless_domains = PAGE
+headless_domains {
+    typeNum = 1608564571
+
+    config {
+        no_cache = 0
+        sendCacheHeaders = 1
+        debug = 0
+        admPanel = 0
+        disableAllHeaderCode = 1
+        additionalHeaders.10 {
+            header = Content-Type: application/json; charset=utf-8
+            replace = 1
+        }
+    }
+
+    10 = JSON
+    10 {
+        fields {
+            domains = TEXT
+            domains {
+                dataProcessing {
+                    10 = FriendsOfTYPO3\Headless\DataProcessing\RootSitesProcessor
+                    10 {
+                        as = sites
+                        siteSchema = FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\DomainSchema
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Configuration/TypoScript/Configuration/Domains.typoscript
+++ b/Configuration/TypoScript/Configuration/Domains.typoscript
@@ -16,16 +16,11 @@ headless_domains {
 
     10 = JSON
     10 {
-        fields {
-            domains = TEXT
-            domains {
-                dataProcessing {
-                    10 = FriendsOfTYPO3\Headless\DataProcessing\RootSitesProcessor
-                    10 {
-                        as = sites
-                        siteSchema = FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\DomainSchema
-                    }
-                }
+        dataProcessing {
+            10 = FriendsOfTYPO3\Headless\DataProcessing\RootSitesProcessor
+            10 {
+                as = sites
+                siteSchema = FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\DomainSchema
             }
         }
     }


### PR DESCRIPTION
- add default SiteProvider (combines data from yaml files & database) with optional custom sorting
- add default SiteSchema (outputs domain list for site switcher)
- add default DomainSchema (outputs domain configuration for nuxt-typo3 app)

All providers & schemas are switchable by implementing proper interface
and configure it in data processor options