### PR TITLE
[BUGFIX] cleanup filepath from file proxy setting

### DIFF
--- a/Classes/XClass/ImageService.php
+++ b/Classes/XClass/ImageService.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2021
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\XClass;
+
+use FriendsOfTYPO3\Headless\Utility\FrontendBaseUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function rtrim;
+use function str_replace;
+
+class ImageService extends \TYPO3\CMS\Extbase\Service\ImageService
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getImageFromSourceString(string $src, bool $treatIdAsReference): object
+    {
+        if ($this->environmentService->isEnvironmentInFrontendMode()) {
+            $conf = $GLOBALS['TYPO3_REQUEST']->getAttribute('site')->getConfiguration();
+            $frontendBase = GeneralUtility::makeInstance(FrontendBaseUtility::class);
+            $baseUriForProxy = rtrim($frontendBase->resolveWithVariants(
+                $conf['frontendApiProxy'] ?? '',
+                $conf['baseVariants'] ?? null,
+                'frontendApiProxy'
+            ), '/');
+
+            if ($baseUriForProxy) {
+                $src = str_replace($baseUriForProxy . '/', '', $src);
+            }
+        }
+
+        return parent::getImageFromSourceString($src, $treatIdAsReference);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -41,6 +41,10 @@ call_user_func(
                 'className' => FriendsOfTYPO3\Headless\XClass\ResourceLocalDriver::class
             ];
 
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Extbase\Service\ImageService::class] = [
+                'className' => FriendsOfTYPO3\Headless\XClass\ImageService::class
+            ];
+
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Core\Routing\PageRouter::class] = [
                 'className' => FriendsOfTYPO3\Headless\XClass\Routing\PageRouter::class
             ];


### PR DESCRIPTION
When processing files via PWA file proxy, ImageService receives bad file src path and do not find file in storage then crash with exception.