### PR TITLE
[TASK] introduce support ext:redirect for nuxt-typo3

### DIFF
--- a/Classes/Event/Listener/RedirectUrlAdditionalParamsListener.php
+++ b/Classes/Event/Listener/RedirectUrlAdditionalParamsListener.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2021
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Event\Listener;
+
+use FriendsOfTYPO3\Headless\Event\RedirectUrlEvent;
+use FriendsOfTYPO3\Headless\Service\SiteService;
+use FriendsOfTYPO3\Headless\XClass\Routing\PageRouter;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use TYPO3\CMS\Core\LinkHandling\LinkService;
+use TYPO3\CMS\Core\Resource\Exception\InvalidPathException;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Service\TypoLinkCodecService;
+
+use function parse_str;
+use function strpos;
+
+class RedirectUrlAdditionalParamsListener implements LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var TypoLinkCodecService
+     */
+    private $typoLinkCodecService;
+    /**
+     * @var LinkService
+     */
+    private $linkService;
+    /**
+     * @var SiteService
+     */
+    private $siteService;
+
+    public function __construct(TypoLinkCodecService $typoLinkCodecService, LinkService $linkService, SiteService $siteService)
+    {
+        $this->typoLinkCodecService = $typoLinkCodecService;
+        $this->linkService = $linkService;
+        $this->siteService = $siteService;
+    }
+
+    public function __invoke(RedirectUrlEvent $event): void
+    {
+        $request = $event->getRequest();
+        $port = $request->getUri()->getPort();
+        $url = $event->getOriginalTargetUrl();
+
+        if ($url->getPath() === $request->getUri()->getPath()) {
+            return;
+        }
+
+        $linkParameterParts = $this->typoLinkCodecService->decode((string)($event->getRedirectRecord()['target'] ?? ''));
+        $redirectTarget = $linkParameterParts['url'] ?? '';
+        $linkDetails = $this->resolveLinkDetailsFromLinkTarget($redirectTarget);
+
+        if ($linkDetails['type'] === LinkService::TYPE_PAGE) {
+            if (strpos($linkParameterParts['additionalParams'], '[action]=') > 0 && strpos($linkParameterParts['additionalParams'], '[controller]=') > 0) {
+                try {
+                    $site = $request->getAttribute('site');
+                    parse_str($linkParameterParts['url'], $typolinkData);
+                    parse_str($linkParameterParts['additionalParams'], $params);
+                    $languageId = $typolinkData['L'] ? (int)$typolinkData['L'] : 0;
+                    if ($languageId > 0) {
+                        $language = $site->getLanguageById($languageId);
+                        $params['_language'] = $language;
+                    }
+                    $frontendUrl = GeneralUtility::makeInstance(PageRouter::class, $site)->generateUri($linkDetails['pageuid'], $params);
+                    $frontendUrl = $this->siteService->getFrontendUrl((string)$frontendUrl, (int)$linkDetails['pageuid']);
+                    $event->setTargetUrl($frontendUrl);
+                } catch (\Exception $exception) {
+                    $this->logger->error('Error during action redirect', ['record' => $event->getRedirectRecord(), 'uri' => $url]);
+                }
+            }
+        } elseif ($linkDetails['type'] === LinkService::TYPE_FILE) {
+            $frontendUrl = 'https://' . $request->getUri()->getHost() . ($port ? ':' . $port : '') . '/' . $linkDetails['url'];
+            $event->setTargetUrl($frontendUrl);
+        }
+    }
+
+    /**
+     * @param string $redirectTarget
+     * @return array
+     */
+    protected function resolveLinkDetailsFromLinkTarget(string $redirectTarget): array
+    {
+        try {
+            $linkDetails = $this->linkService->resolve($redirectTarget);
+            switch ($linkDetails['type']) {
+                case LinkService::TYPE_URL:
+                    // all set up, nothing to do
+                    break;
+                case LinkService::TYPE_FILE:
+                    /** @var File $file */
+                    $file = $linkDetails['file'];
+                    if ($file instanceof File) {
+                        $linkDetails['url'] = $file->getPublicUrl();
+                    }
+                    break;
+                case LinkService::TYPE_FOLDER:
+                    /** @var Folder $folder */
+                    $folder = $linkDetails['folder'];
+                    if ($folder instanceof Folder) {
+                        $linkDetails['url'] = $folder->getPublicUrl();
+                    }
+                    break;
+                default:
+                    // we have to return the link details without having a "URL" parameter
+
+            }
+        } catch (InvalidPathException $e) {
+            return [];
+        }
+        return $linkDetails;
+    }
+}

--- a/Classes/Event/RedirectUrlEvent.php
+++ b/Classes/Event/RedirectUrlEvent.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2021
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Event;
+
+use Psr\EventDispatcher\StoppableEventInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+class RedirectUrlEvent implements StoppableEventInterface
+{
+    private $propagationStopped = false;
+    /**
+     * @var string
+     */
+    private $targetUrl;
+    /**
+     * @var array<string, mixed>
+     */
+    private $redirectRecord;
+    /**
+     * @var int
+     */
+    private $targetStatusCode;
+    /**
+     * @var ServerRequestInterface
+     */
+    private $request;
+    /**
+     * @var UriInterface
+     */
+    private $originalTargetUrl;
+
+    /**
+     * @param string $targetUrl
+     * @param array $redirectRecord
+     */
+    public function __construct(
+        ServerRequestInterface $request,
+        UriInterface $originalTargetUrl,
+        string $targetUrl,
+        int $targetStatusCode,
+        array $redirectRecord
+    ) {
+        $this->request = $request;
+        $this->targetUrl = $targetUrl;
+        $this->redirectRecord = $redirectRecord;
+        $this->targetStatusCode = $targetStatusCode;
+        $this->originalTargetUrl = $originalTargetUrl;
+    }
+
+    /**
+     * @return ServerRequestInterface
+     */
+    public function getRequest(): ServerRequestInterface
+    {
+        return $this->request;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     */
+    public function setRequest(ServerRequestInterface $request): void
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTargetUrl(): string
+    {
+        return $this->targetUrl;
+    }
+
+    /**
+     * @param string $targetUrl
+     */
+    public function setTargetUrl(string $targetUrl): void
+    {
+        $this->targetUrl = $targetUrl;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTargetStatusCode(): int
+    {
+        return $this->targetStatusCode;
+    }
+
+    /**
+     * @param int $targetStatusCode
+     */
+    public function setTargetStatusCode(int $targetStatusCode): void
+    {
+        $this->targetStatusCode = $targetStatusCode;
+    }
+
+    /**
+     * @return UriInterface
+     */
+    public function getOriginalTargetUrl(): UriInterface
+    {
+        return $this->originalTargetUrl;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getRedirectRecord(): array
+    {
+        return $this->redirectRecord;
+    }
+
+    public function isPropagationStopped(): bool
+    {
+        return $this->propagationStopped;
+    }
+
+    public function stopPropagation(): void
+    {
+        $this->propagationStopped = true;
+    }
+}

--- a/Classes/Middleware/RedirectHandler.php
+++ b/Classes/Middleware/RedirectHandler.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2021
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Middleware;
+
+use FriendsOfTYPO3\Headless\Event\RedirectUrlEvent;
+use FriendsOfTYPO3\Headless\Service\SiteService;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\LinkHandling\LinkService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Redirects\Service\RedirectService;
+
+final class RedirectHandler extends \TYPO3\CMS\Redirects\Http\Middleware\RedirectHandler
+{
+    /**
+     * @var SiteService
+     */
+    private $siteService;
+    /**
+     * @var LinkService
+     */
+    private $linkService;
+    /**
+     * @var EventDispatcherInterface|null
+     */
+    private $eventDispatcher;
+    /**
+     * @var ServerRequestInterface
+     */
+    private $request;
+
+    public function __construct(
+        RedirectService $redirectService,
+        SiteService $siteService = null,
+        LinkService $linkService = null,
+        EventDispatcher $eventDispatcher = null
+    ) {
+        parent::__construct($redirectService);
+        $this->siteService = $siteService ?? GeneralUtility::makeInstance(SiteService::class);
+        $this->linkService = $linkService ?? GeneralUtility::makeInstance(LinkService::class);
+
+        if ((new Typo3Version())->getMajorVersion() >= 10) {
+            $this->eventDispatcher = $eventDispatcher ?? GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $this->request = $request;
+        return parent::process($request, $handler);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function buildRedirectResponse(UriInterface $uri, array $redirectRecord): ResponseInterface
+    {
+        $resolvedTarget = $this->linkService->resolve($redirectRecord['target']);
+        $targetUrl = $this->siteService->getFrontendUrl((string)$uri, (int)$resolvedTarget['pageuid']);
+
+        $redirectUrlEvent = new RedirectUrlEvent(
+            $this->request,
+            $uri,
+            $targetUrl,
+            (int)$redirectRecord['target_statuscode'],
+            $redirectRecord
+        );
+
+        if ($this->eventDispatcher) {
+            $redirectUrlEvent = $this->eventDispatcher->dispatch($redirectUrlEvent);
+        } else {
+            $redirectUrlEvent = $this->dispatchHooks($redirectUrlEvent);
+        }
+
+        return new JsonResponse([
+            'redirectUrl' => $redirectUrlEvent->getTargetUrl(),
+            'statusCode' => $redirectUrlEvent->getTargetStatusCode()
+        ]);
+    }
+
+    private function dispatchHooks(RedirectUrlEvent $redirectUrlEvent): RedirectUrlEvent
+    {
+        foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['headless']['hooks']['redirectUrl'] ?? [] as $hook) {
+            $_params = [
+                'pObj' => &$this,
+                'redirectUrlEvent' => $redirectUrlEvent,
+            ];
+
+            $parsedEventByHooks = GeneralUtility::callUserFunction($hook, $_params, $this);
+
+            if ($parsedEventByHooks instanceof RedirectUrlEvent) {
+                $redirectUrlEvent = $parsedEventByHooks;
+            }
+        }
+
+        return $redirectUrlEvent;
+    }
+}

--- a/Classes/Middleware/RedirectHandler.php
+++ b/Classes/Middleware/RedirectHandler.php
@@ -75,6 +75,10 @@ final class RedirectHandler extends \TYPO3\CMS\Redirects\Http\Middleware\Redirec
      */
     protected function buildRedirectResponse(UriInterface $uri, array $redirectRecord): ResponseInterface
     {
+        if (!($this->request->getAttribute('site')->getConfiguration()['headless'] ?? false)) {
+            return parent::buildRedirectResponse($uri, $redirectRecord);
+        }
+
         $resolvedTarget = $this->linkService->resolve($redirectRecord['target']);
         $targetUrl = $this->siteService->getFrontendUrl((string)$uri, (int)$resolvedTarget['pageuid']);
 
@@ -92,10 +96,12 @@ final class RedirectHandler extends \TYPO3\CMS\Redirects\Http\Middleware\Redirec
             $redirectUrlEvent = $this->dispatchHooks($redirectUrlEvent);
         }
 
-        return new JsonResponse([
-            'redirectUrl' => $redirectUrlEvent->getTargetUrl(),
-            'statusCode' => $redirectUrlEvent->getTargetStatusCode()
-        ]);
+        return new JsonResponse(
+            [
+                'redirectUrl' => $redirectUrlEvent->getTargetUrl(),
+                'statusCode' => $redirectUrlEvent->getTargetStatusCode()
+            ]
+        );
     }
 
     private function dispatchHooks(RedirectUrlEvent $redirectUrlEvent): RedirectUrlEvent

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -16,10 +16,24 @@ return (static function (): array {
         return [];
     }
 
+    $rearrangedMiddlewares = $features->isFeatureEnabled('rearrangedRedirectMiddlewares');
+
     return [
         'frontend' => [
+            'typo3/cms-redirects/redirecthandler' => [
+                'disabled' => true,
+            ],
             'typo3/cms-frontend/shortcut-and-mountpoint-redirect' => [
                 'disabled' => true
+            ],
+            'headless/cms-redirects/redirecthandler' => [
+                'target' => \FriendsOfTYPO3\Headless\Middleware\RedirectHandler::class,
+                'before' => [
+                    $rearrangedMiddlewares ? 'typo3/cms-frontend/base-redirect-resolver' : 'typo3/cms-frontend/page-resolver',
+                ],
+                'after' => [
+                    $rearrangedMiddlewares ? 'typo3/cms-frontend/authentication' : 'typo3/cms-frontend/static-route-resolver',
+                ],
             ],
             'headless/cms-frontend/shortcut-and-mountpoint-redirect' => [
                 'target' => \FriendsOfTYPO3\Headless\Middleware\ShortcutAndMountPointRedirect::class,


### PR DESCRIPTION
- behind `headless.redirectMiddlewares` flag & `headless` flag in site config
- replace original redirectHandler with headless one
- introduce RedirectUrlEvent for EventDispatcher/hook for TYPO3 v9.5 to allow customizations of redirect url without replacing middleware
- introduce optional listener for handling additionalParams in redirect url
- add support for `headless.storageProxy` in file redirection