### PR TITLE
[FEATURE] add support for clean output for plugins

### DIFF
--- a/Classes/Middleware/PluginBodyResponseMiddleware.php
+++ b/Classes/Middleware/PluginBodyResponseMiddleware.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * (c) 2021
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Middleware;
+
+use FriendsOfTYPO3\Headless\Json\JsonEncoder;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+class PluginBodyResponseMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var TypoScriptFrontendController
+     */
+    private $tsfe;
+    /**
+     * @var JsonEncoder
+     */
+    private $jsonEncoder;
+
+    public function __construct(
+        TypoScriptFrontendController $typoScriptFrontendController = null,
+        JsonEncoder $jsonEncoder = null
+    ) {
+        $this->tsfe = $typoScriptFrontendController ?? $GLOBALS['TSFE'];
+        $this->jsonEncoder = $jsonEncoder ?? GeneralUtility::makeInstance(JsonEncoder::class);
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        if (!isset($this->tsfe->tmpl->setup['plugin.']['tx_headless.']['staticTemplate'])
+            || (bool)$this->tsfe->tmpl->setup['plugin.']['tx_headless.']['staticTemplate'] === false
+        ) {
+            return $response;
+        }
+
+        $pluginId = (int)($request->getParsedBody()['responsePluginId'] ?? 0);
+
+        if (!$pluginId || !in_array($request->getMethod(), ['POST', 'PUT', 'DELETE'], true)) {
+            return $response;
+        }
+
+        $responseJson = json_decode($response->getBody()->__toString(), true);
+
+        if ($responseJson === null) {
+            return $response;
+        }
+
+        $stream = new Stream('php://temp', 'r+');
+        $stream->write($this->jsonEncoder->encode($this->getPluginBody($responseJson['content'] ?? [], $pluginId)));
+
+        return $response->withBody($stream);
+    }
+
+    /**
+     * @param array<string, mixed> $content
+     * @param int $pluginId
+     * @return array<string, mixed>
+     */
+    private function getPluginBody(array $content, int $pluginId): array
+    {
+        $body = [];
+
+        foreach ($content as $colPos => $items) {
+            foreach ($items as $item) {
+                if ((int)$item['id'] === $pluginId) {
+                    return $item;
+                }
+            }
+        }
+
+        return $body;
+    }
+}

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -23,6 +23,15 @@ return (static function (): array {
         ],
     ];
 
+    if ($features->isFeatureEnabled('headless.pluginBodyResponse')) {
+        $middlewares['frontend']['headless/cms-frontend/plugin-body-response'] = [
+            'after' => [
+                'typo3/cms-adminpanel/data-persister',
+            ],
+            'target' => \FriendsOfTYPO3\Headless\Middleware\PluginBodyResponseMiddleware::class
+        ];
+    }
+
     if (!$features->isFeatureEnabled('headless.redirectMiddlewares')) {
         return $middlewares;
     }

--- a/README.md
+++ b/README.md
@@ -195,6 +195,23 @@ Enable new APIs/behaviors of ext:headless, but contains breaking changes & requi
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['headless.nextMajor'] = true;
 ```
 
+**headless.pluginBodyResponse**
+
+Available since `> 2.5.3`
+
+Enable clean output middleware for plugins. Clean output is available for POST/PUT/DELETE method requests.
+For getting clean for plugins on page, please enable this flag and send `responsePluginId` field with ID of plugin in body with plugin data.
+```
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['headless.pluginBodyResponse'] = true;
+```
+Example POST request with plugin form. Please #PLUGIN_ID# replace with id of plugin from page response
+```
+POST https://example.tld/path-to-form-plugin
+Content-Type: application/x-www-form-urlencoded
+
+responsePluginId=#PLUGIN_ID#&tx_form_formframework[email]=email&tx_form_formframework[name]=test...
+```
+
 
 ## Development
 Development for this extension is happening as part of the TYPO3 PWA initiative, see https://typo3.org/community/teams/typo3-development/initiatives/pwa/


### PR DESCRIPTION
- add new `headless.pluginBodyResponse` feature flag (off by default)
- requires sending `responsePluginId` with plugin data to receive clean output
- works only for POST/PUT/DELETE requests

resolves #191