### PR TITLE
[TASK] Fix configuration

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,8 +20,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.6.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.4.0-11.5.99',
-            'frontend' => '11.4.0-11.5.99'
+            'frontend' => '11.4.0-11.5.99',
+            'typo3' => '11.4.0-11.5.99'
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
With TYPO3 11.5 and PHP 8.0 there was a critical error with DI while using headless extension.