### PR TITLE
[TASK] Drop final class annotations to support all TYPO3s expendability options

### DIFF
--- a/Classes/ContentObject/JsonContentObject.php
+++ b/Classes/ContentObject/JsonContentObject.php
@@ -29,7 +29,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 use function strpos;
 
-final class JsonContentObject extends AbstractContentObject implements LoggerAwareInterface
+class JsonContentObject extends AbstractContentObject implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 

--- a/Classes/DataProcessing/RootSiteProcessing/DomainSchema.php
+++ b/Classes/DataProcessing/RootSiteProcessing/DomainSchema.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use function is_array;
 use function str_replace;
 
-final class DomainSchema implements SiteSchemaInterface
+class DomainSchema implements SiteSchemaInterface
 {
     private HeadlessFrontendUrlInterface $urlUtility;
     private ContentDataProcessor $contentDataProcessor;

--- a/Classes/DataProcessing/RootSiteProcessing/SiteProvider.php
+++ b/Classes/DataProcessing/RootSiteProcessing/SiteProvider.php
@@ -25,7 +25,7 @@ use function count;
 use function in_array;
 use function usort;
 
-final class SiteProvider implements SiteProviderInterface
+class SiteProvider implements SiteProviderInterface
 {
     /**
      * @var ConnectionPool

--- a/Classes/DataProcessing/RootSiteProcessing/SiteSchema.php
+++ b/Classes/DataProcessing/RootSiteProcessing/SiteSchema.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use function is_array;
 use function trim;
 
-final class SiteSchema implements SiteSchemaInterface
+class SiteSchema implements SiteSchemaInterface
 {
     private HeadlessFrontendUrlInterface $urlUtitlity;
     private ContentDataProcessor $contentDataProcessor;

--- a/Classes/DataProcessing/RootSitesProcessor.php
+++ b/Classes/DataProcessing/RootSitesProcessor.php
@@ -62,7 +62,7 @@ use function sprintf;
     }
  */
 
-final class RootSitesProcessor implements DataProcessorInterface
+class RootSitesProcessor implements DataProcessorInterface
 {
     /**
      * @param ContentObjectRenderer $cObj

--- a/Classes/Dto/JsonViewDemand.php
+++ b/Classes/Dto/JsonViewDemand.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * @codeCoverageIgnore
  */
-final class JsonViewDemand implements JsonViewDemandInterface
+class JsonViewDemand implements JsonViewDemandInterface
 {
     /**
      * @var int

--- a/Classes/Form/Decorator/FormDefinitionDecorator.php
+++ b/Classes/Form/Decorator/FormDefinitionDecorator.php
@@ -11,6 +11,6 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\Form\Decorator;
 
-final class FormDefinitionDecorator extends AbstractFormDefinitionDecorator
+class FormDefinitionDecorator extends AbstractFormDefinitionDecorator
 {
 }

--- a/Classes/Form/Translator.php
+++ b/Classes/Form/Translator.php
@@ -18,7 +18,7 @@ use function array_merge;
 use function array_replace_recursive;
 use function is_array;
 
-final class Translator
+class Translator
 {
     protected static function getTranslationService(): FormTranslationService
     {

--- a/Classes/Json/JsonDecoder.php
+++ b/Classes/Json/JsonDecoder.php
@@ -18,7 +18,7 @@ use function is_string;
 use function json_decode;
 use function trim;
 
-final class JsonDecoder implements JsonDecoderInterface
+class JsonDecoder implements JsonDecoderInterface
 {
     /**
      * @inheritDoc

--- a/Classes/Json/JsonEncoder.php
+++ b/Classes/Json/JsonEncoder.php
@@ -18,7 +18,7 @@ use function json_encode;
 
 use const JSON_THROW_ON_ERROR;
 
-final class JsonEncoder implements JsonEncoderInterface, LoggerAwareInterface
+class JsonEncoder implements JsonEncoderInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 

--- a/Classes/Middleware/ElementBodyResponseMiddleware.php
+++ b/Classes/Middleware/ElementBodyResponseMiddleware.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Core\Http\Stream;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
-final class ElementBodyResponseMiddleware implements MiddlewareInterface
+class ElementBodyResponseMiddleware implements MiddlewareInterface
 {
     /**
      * @var TypoScriptFrontendController

--- a/Classes/Middleware/RedirectHandler.php
+++ b/Classes/Middleware/RedirectHandler.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Redirects\Service\RedirectService;
 
 use function strpos;
 
-final class RedirectHandler extends \TYPO3\CMS\Redirects\Http\Middleware\RedirectHandler
+class RedirectHandler extends \TYPO3\CMS\Redirects\Http\Middleware\RedirectHandler
 {
     private LinkService $linkService;
     private EventDispatcherInterface $eventDispatcher;

--- a/Classes/Middleware/ShortcutAndMountPointRedirect.php
+++ b/Classes/Middleware/ShortcutAndMountPointRedirect.php
@@ -24,7 +24,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use function is_array;
 use function parse_url;
 
-final class ShortcutAndMountPointRedirect implements MiddlewareInterface
+class ShortcutAndMountPointRedirect implements MiddlewareInterface
 {
     private TypoScriptFrontendController $controller;
 

--- a/Classes/Service/BackendTsfeService.php
+++ b/Classes/Service/BackendTsfeService.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 /**
  * @codeCoverageIgnore
  */
-final class BackendTsfeService implements BackendTsfeServiceInterface
+class BackendTsfeService implements BackendTsfeServiceInterface
 {
     private array $backendExtensionConfiguration = [];
 

--- a/Classes/Service/JsonViewConfigurationService.php
+++ b/Classes/Service/JsonViewConfigurationService.php
@@ -24,7 +24,7 @@ use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 /**
  * @codeCoverageIgnore
  */
-final class JsonViewConfigurationService implements JsonViewConfigurationServiceInterface
+class JsonViewConfigurationService implements JsonViewConfigurationServiceInterface
 {
     protected array $settings = [];
     protected JsonViewDemandInterface $demand;

--- a/Classes/Utility/UrlUtility.php
+++ b/Classes/Utility/UrlUtility.php
@@ -29,7 +29,7 @@ use function rtrim;
 use function str_replace;
 use function strpos;
 
-final class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
+class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
 {
     use LoggerAwareTrait;
 


### PR DESCRIPTION
Related to https://github.com/TYPO3-Initiatives/headless/issues/381 I dropped the final keywords to increase the expendability of the extension.