### PR TITLE
[BUGFIX] Resolve #383 - Avoid calling toArray and split properties in…

### DIFF
--- a/Tests/Unit/Utility/FileUtilityTest.php
+++ b/Tests/Unit/Utility/FileUtilityTest.php
@@ -322,6 +322,7 @@ class FileUtilityTest extends UnitTestCase
                     'title' => null,
                     'alternative' => null,
                     'description' => null,
+                    'link' => null,
                     'mimeType' => 'image/jpeg',
                     'type' => 'image',
                     'filename' => 'test-file.jpg',
@@ -329,7 +330,6 @@ class FileUtilityTest extends UnitTestCase
                     'uidLocal' => null,
                     'fileReferenceUid' => 103,
                     'size' => '71 KB',
-                    'link' => null,
                     'dimensions' =>
                         [
                             'width' => 526,
@@ -356,6 +356,7 @@ class FileUtilityTest extends UnitTestCase
                     'title' => null,
                     'alternative' => null,
                     'description' => null,
+                    'link' => null,
                     'mimeType' => 'image/jpeg',
                     'type' => 'image',
                     'filename' => 'test-file.jpg',
@@ -363,7 +364,6 @@ class FileUtilityTest extends UnitTestCase
                     'uidLocal' => 103,
                     'fileReferenceUid' => 103,
                     'size' => '71 KB',
-                    'link' => null,
                     'dimensions' =>
                         [
                             'width' => 526,
@@ -390,6 +390,7 @@ class FileUtilityTest extends UnitTestCase
                     'title' => null,
                     'alternative' => null,
                     'description' => null,
+                    'link' => null,
                     'mimeType' => 'video/youtube',
                     'type' => 'video',
                     'filename' => 'test-file.jpg',
@@ -397,7 +398,6 @@ class FileUtilityTest extends UnitTestCase
                     'uidLocal' => 103,
                     'fileReferenceUid' => 103,
                     'size' => '71 KB',
-                    'link' => null,
                     'dimensions' =>
                         [
                             'width' => 526,


### PR DESCRIPTION
…to original and processed details

Resolve https://github.com/TYPO3-Initiatives/headless/issues/383

Do not call "toArray" on the Reference (solve problems with EXT:filefill) and split the property selection into two parts (before the processing and after the processing) to get the meta information of the original.