### PR TITLE
[BUGFIX][BACKPORT] Render typolink file URLs as absolute

### DIFF
--- a/Classes/Hooks/FileOrFolderLinkBuilder.php
+++ b/Classes/Hooks/FileOrFolderLinkBuilder.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Hooks;
+
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Typolink\UnableToLinkException;
+
+class FileOrFolderLinkBuilder extends \TYPO3\CMS\Frontend\Typolink\FileOrFolderLinkBuilder
+{
+    /**
+     * {@inheritDoc}
+     * @throws UnableToLinkException
+     */
+    public function build(array &$linkDetails, string $linkText, string $target, array $conf): array
+    {
+        $setup = $GLOBALS['TSFE'] instanceof TypoScriptFrontendController ? $GLOBALS['TSFE']->tmpl->setup : null;
+
+        if (
+            array_key_exists('type', $linkDetails)
+            && $linkDetails['type'] === 'file'
+            && isset($setup['plugin.']['tx_headless.']['staticTemplate'])
+            && (bool)$setup['plugin.']['tx_headless.']['staticTemplate'] === true
+        ) {
+            $conf['forceAbsoluteUrl'] = 1;
+        }
+
+        return parent::build($linkDetails, $linkText, $target, $conf);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -23,6 +23,7 @@ call_user_func(
             'INT' => \FriendsOfTYPO3\Headless\ContentObject\IntegerContentObject::class,
             'BOOL' => \FriendsOfTYPO3\Headless\ContentObject\BooleanContentObject::class,
         ]);
+        $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['file'] = \FriendsOfTYPO3\Headless\Hooks\FileOrFolderLinkBuilder::class;
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['headless'] = [
             'FriendsOfTYPO3\Headless\ViewHelpers'
         ];


### PR DESCRIPTION
Currently URLs generated for typolink files (for instance, in RTE
content elements) are being rendered as relative links. This commit
changes them to be rendered as absolute, because relative URLs don't
work when loading images from an external domain.