### PR TITLE
Extended Dataprocessors

### DIFF
--- a/Classes/DataProcessing/DatabaseQueryProcessor.php
+++ b/Classes/DataProcessing/DatabaseQueryProcessor.php
@@ -129,6 +129,16 @@ class DatabaseQueryProcessor implements DataProcessorInterface
 
             $processedRecordVariables[$key] = $record;
             $processedRecordVariables[$key] = $this->contentDataProcessor->process($recordContentObjectRenderer, $processorConfiguration, $processedRecordVariables[$key]);
+
+            if (isset($processorConfiguration['overrideFields.'])) {
+                $overrideFields = $this->typoScriptService->convertTypoScriptArrayToPlainArray($processorConfiguration['overrideFields.']);
+                $jsonCE = $this->typoScriptService->convertPlainArrayToTypoScriptArray(['fields' => $overrideFields, '_typoScriptNodeValue' => 'JSON']);
+                $record = \json_decode($recordContentObjectRenderer->cObjGetSingle('JSON', $jsonCE), true);
+
+                foreach ($record as $fieldName => $overrideData) {
+                    $processedRecordVariables[$key][$fieldName] = $overrideData;
+                }
+            }
         }
 
         return $processedRecordVariables;

--- a/Classes/DataProcessing/FlexFormProcessor.php
+++ b/Classes/DataProcessing/FlexFormProcessor.php
@@ -64,12 +64,12 @@ class FlexFormProcessor implements DataProcessorInterface
             $fieldName = 'pi_flexform';
         }
 
-        if (!$processedData['data'][$fieldName]) {
+        if (!$processedData['data'][$fieldName] && !$processedData[$fieldName]) {
             return $processedData;
         }
 
         // processing the flexform data
-        $originalValue = $processedData['data'][$fieldName];
+        $originalValue = $processedData['data'][$fieldName] ?? $processedData[$fieldName];
 
         if (\is_array($originalValue)) {
             $flexformData = $originalValue;
@@ -85,7 +85,11 @@ class FlexFormProcessor implements DataProcessorInterface
         if (!empty($targetVariableName)) {
             $processedData[$targetVariableName] = $flexformData;
         } else {
-            $processedData['data'][$fieldName] = $flexformData;
+            if ($processedData['data'][$fieldName]) {
+                $processedData['data'][$fieldName] = $flexformData;
+            } else {
+                $processedData[$fieldName] = $flexformData;
+            }
         }
 
         return $processedData;


### PR DESCRIPTION
### Update FlexFormProcessor.php
Added the possibility to process data, which is in $processedData[$fieldName] instead of $processedData['data'][$fieldName]. 
We needed this to process flexform data in a result of the DatabaseQueryProcessor.


### Update DatabaseQueryProcessor.php
This makes it possible, to configure only one field of the result.
We have a link field, which wasn't parsed as typolink. But we didn't want to define every single field of the query. So we added the key "overrideFields".
e.g.:
```
20 = FriendsOfTYPO3Headless\HeadlessBootstrapPackage\DataProcessing\DatabaseQueryProcessor
20 {
  table = tx_bootstrappackage_carousel_item
  pidInList.field = pid
  where {
    data = field:uid
    intval = 1
    wrap = tt_content=|
  }
  overrideFields {
    link = TEXT
    link {
      field = link
      htmlSpecialChars = 1
      typolink {
        parameter {
          field = link
        }
        returnLast = result
      }
    }
  }
  orderBy = sorting
  as = records
}
```