### PR TITLE
[PoC][FEATURE] Introduce mixed mode for headless

### DIFF
--- a/Classes/Hooks/FileOrFolderLinkBuilder.php
+++ b/Classes/Hooks/FileOrFolderLinkBuilder.php
@@ -11,7 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\Hooks;
 
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
 use TYPO3\CMS\Frontend\Typolink\UnableToLinkException;
 
@@ -26,14 +27,9 @@ class FileOrFolderLinkBuilder extends \TYPO3\CMS\Frontend\Typolink\FileOrFolderL
      */
     public function build(array &$linkDetails, string $linkText, string $target, array $conf): LinkResultInterface
     {
-        $setup = ($GLOBALS['TSFE'] ?? null) instanceof TypoScriptFrontendController ? $GLOBALS['TSFE']->tmpl->setup : null;
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST']);
 
-        if (
-            array_key_exists('type', $linkDetails)
-            && $linkDetails['type'] === 'file'
-            && isset($setup['plugin.']['tx_headless.']['staticTemplate'])
-            && (bool)$setup['plugin.']['tx_headless.']['staticTemplate'] === true
-        ) {
+        if ($headlessMode->isEnabled()) {
             $conf['forceAbsoluteUrl'] = 1;
         }
 

--- a/Classes/Middleware/ElementBodyResponseMiddleware.php
+++ b/Classes/Middleware/ElementBodyResponseMiddleware.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Headless\Middleware;
 
 use FriendsOfTYPO3\Headless\Json\JsonEncoder;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -26,10 +27,12 @@ use function json_decode;
 class ElementBodyResponseMiddleware implements MiddlewareInterface
 {
     private JsonEncoder $jsonEncoder;
+    private HeadlessMode $headlessMode;
 
-    public function __construct(JsonEncoder $jsonEncoder = null)
+    public function __construct(JsonEncoder $jsonEncoder = null, HeadlessMode $headlessMode)
     {
         $this->jsonEncoder = $jsonEncoder;
+        $this->headlessMode = $headlessMode;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -45,9 +48,7 @@ class ElementBodyResponseMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        $siteConf = $request->getAttribute('site')->getConfiguration();
-
-        if (!($siteConf['headless'] ?? false)) {
+        if (!$this->headlessMode->withRequest($request)->isEnabled()) {
             return $response;
         }
 

--- a/Classes/Middleware/HeadlessModeSetter.php
+++ b/Classes/Middleware/HeadlessModeSetter.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Middleware;
+
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Site\Entity\Site;
+
+class HeadlessModeSetter implements MiddlewareInterface
+{
+    public function __construct()
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $mode = HeadlessMode::NONE;
+
+        /**
+         * @var Site $site
+         */
+        $site = $request->getAttribute('site');
+        if ($site) {
+            $mode = (int)($site->getConfiguration()['headless'] ?? HeadlessMode::NONE);
+        }
+
+        $request = $request->withAttribute('headless', new Headless($mode));
+
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+        return $handler->handle($request);
+    }
+}

--- a/Classes/Middleware/HeadlessModeSetter.php
+++ b/Classes/Middleware/HeadlessModeSetter.php
@@ -21,9 +21,7 @@ use TYPO3\CMS\Core\Site\Entity\Site;
 
 class HeadlessModeSetter implements MiddlewareInterface
 {
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/Classes/Middleware/RedirectHandler.php
+++ b/Classes/Middleware/RedirectHandler.php
@@ -13,6 +13,7 @@ namespace FriendsOfTYPO3\Headless\Middleware;
 
 use FriendsOfTYPO3\Headless\Event\RedirectUrlEvent;
 use FriendsOfTYPO3\Headless\Utility\HeadlessFrontendUrlInterface;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -31,6 +32,7 @@ final class RedirectHandler extends \TYPO3\CMS\Redirects\Http\Middleware\Redirec
 {
     private ServerRequestInterface $request;
     private HeadlessFrontendUrlInterface $urlUtility;
+    private HeadlessMode $headlessMode;
 
     public function __construct(
         RedirectService $redirectService,
@@ -66,9 +68,7 @@ final class RedirectHandler extends \TYPO3\CMS\Redirects\Http\Middleware\Redirec
             return parent::buildRedirectResponse($uri, $redirectRecord);
         }
 
-        $siteConf = $this->request->getAttribute('site')->getConfiguration();
-
-        if (!($siteConf['headless'] ?? false)) {
+        if (!$this->headlessMode->withRequest($this->request)->isEnabled()) {
             return parent::buildRedirectResponse($uri, $redirectRecord);
         }
 

--- a/Classes/Middleware/ShortcutAndMountPointRedirect.php
+++ b/Classes/Middleware/ShortcutAndMountPointRedirect.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\Middleware;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -22,7 +23,6 @@ use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Routing\PageArguments;
-use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\ErrorController;
 
@@ -34,6 +34,11 @@ use function parse_url;
 class ShortcutAndMountPointRedirect implements MiddlewareInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
+
+    public function __construct(private readonly HeadlessMode $headlessMode)
+    {
+    }
+
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $queryParams = $request->getQueryParams();
@@ -137,17 +142,6 @@ class ShortcutAndMountPointRedirect implements MiddlewareInterface, LoggerAwareI
 
     private function isHeadlessEnabled(ServerRequestInterface $request): bool
     {
-        /**
-         * @var Site
-         */
-        $site = $request->getAttribute('site');
-
-        if (!($site instanceof Site)) {
-            return false;
-        }
-
-        $siteConf = $request->getAttribute('site')->getConfiguration();
-
-        return $siteConf['headless'] ?? false;
+        return $this->headlessMode->withRequest($request)->isEnabled();
     }
 }

--- a/Classes/Middleware/ShortcutAndMountPointRedirect.php
+++ b/Classes/Middleware/ShortcutAndMountPointRedirect.php
@@ -35,9 +35,7 @@ class ShortcutAndMountPointRedirect implements MiddlewareInterface, LoggerAwareI
 {
     use LoggerAwareTrait;
 
-    public function __construct(private readonly HeadlessMode $headlessMode)
-    {
-    }
+    public function __construct(private readonly HeadlessMode $headlessMode) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/Classes/Utility/Headless.php
+++ b/Classes/Utility/Headless.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Utility;
+
+/**
+ * @codeCoverageIgnore
+ */
+final class Headless
+{
+    private int $mode;
+
+    public function __construct(int $mode = HeadlessMode::NONE)
+    {
+        $this->mode = $mode;
+    }
+
+    public function getMode(): int
+    {
+        return $this->mode;
+    }
+}

--- a/Classes/Utility/HeadlessMode.php
+++ b/Classes/Utility/HeadlessMode.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Utility;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class HeadlessMode
+{
+    public const NONE = 0;
+    public const FULL = 1;
+    public const MIXED = 2;
+
+    private ?ServerRequestInterface $request = null;
+
+    public function withRequest(ServerRequestInterface $request): self
+    {
+        $this->request = $request;
+        return $this;
+    }
+    public function isEnabled(): bool
+    {
+        if ($this->request === null) {
+            return false;
+        }
+
+        $headless = $this->request->getAttribute('headless') ?? new Headless();
+
+        if ($headless->getMode() === self::NONE) {
+            return false;
+        }
+
+        return $headless->getMode() === self::FULL ||
+            ($headless->getMode() === self::MIXED && ($this->request->getHeader('Accept')[0] ?? '') === 'application/json');
+    }
+}

--- a/Classes/Utility/UrlUtility.php
+++ b/Classes/Utility/UrlUtility.php
@@ -38,16 +38,19 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
     private SiteFinder $siteFinder;
     private array $conf = [];
     private array $variants = [];
+    private HeadlessMode $headlessMode;
 
     public function __construct(
         ?Features $features = null,
         ?Resolver $resolver = null,
         ?SiteFinder $siteFinder = null,
-        ?ServerRequestInterface $serverRequest = null
+        ?ServerRequestInterface $serverRequest = null,
+        ?HeadlessMode $headlessMode = null
     ) {
         $this->features = $features ?? GeneralUtility::makeInstance(Features::class);
         $this->resolver = $resolver ?? GeneralUtility::makeInstance(Resolver::class, 'site', []);
         $this->siteFinder = $siteFinder ?? GeneralUtility::makeInstance(SiteFinder::class);
+        $this->headlessMode = $headlessMode ?? GeneralUtility::makeInstance(HeadlessMode::class);
         $request = $serverRequest ?? ($GLOBALS['TYPO3_REQUEST'] ?? null);
 
         if ($request instanceof ServerRequestInterface) {
@@ -72,18 +75,17 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
 
     public function getFrontendUrlWithSite($url, SiteInterface $site, string $returnField = 'frontendBase'): string
     {
-        $configuration = $site->getConfiguration();
-
-        if (!($configuration['headless'] ?? false)) {
+        if (!$this->headlessMode->isEnabled()) {
             return $url;
         }
 
         try {
             $base = $site->getBase()->getHost();
             $port = $site->getBase()->getPort();
+            $configuration = $site->getConfiguration();
             $frontendBaseUrl = $this->resolveWithVariants(
                 $configuration[$returnField] ?? '',
-                $configuration['baseVariants'] ?? [],
+                $this->variants,
                 $returnField
             );
 
@@ -268,6 +270,8 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
         if ($language instanceof SiteLanguage) {
             $object->handleLanguageConfiguration($language, $object);
         }
+
+        $object->headlessMode = $object->headlessMode->withRequest($request);
 
         return $object;
     }

--- a/Classes/XClass/Controller/FormFrontendController.php
+++ b/Classes/XClass/Controller/FormFrontendController.php
@@ -15,6 +15,7 @@ use FriendsOfTYPO3\Headless\Form\CustomOptionsInterface;
 use FriendsOfTYPO3\Headless\Form\Decorator\DefinitionDecoratorInterface;
 use FriendsOfTYPO3\Headless\Form\Decorator\FormDefinitionDecorator;
 use FriendsOfTYPO3\Headless\Form\Translator;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\XClass\FormRuntime;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
@@ -23,7 +24,6 @@ use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
 use TYPO3\CMS\Form\Domain\Factory\ArrayFormFactory;
 use TYPO3\CMS\Form\Domain\Model\FormDefinition;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 use function array_merge;
 use function array_pop;
@@ -62,11 +62,9 @@ class FormFrontendController extends \TYPO3\CMS\Form\Controller\FormFrontendCont
      */
     public function renderAction(): ResponseInterface
     {
-        // check if headless not loaded & call original method in case of fluid configuration
-        $typoScriptSetup = $GLOBALS['TSFE'] instanceof TypoScriptFrontendController ? $GLOBALS['TSFE']->tmpl->setup : [];
-        if (!isset($typoScriptSetup['plugin.']['tx_headless.']['staticTemplate'])
-            || (bool)$typoScriptSetup['plugin.']['tx_headless.']['staticTemplate'] === false
-        ) {
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class);
+
+        if (!$headlessMode->withRequest($GLOBALS['TYPO3_REQUEST'])->isEnabled()) {
             return parent::renderAction();
         }
 

--- a/Classes/XClass/Controller/LoginController.php
+++ b/Classes/XClass/Controller/LoginController.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\XClass\Controller;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Security\RequestToken;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -107,8 +108,6 @@ class LoginController extends \TYPO3\CMS\FrontendLogin\Controller\LoginControlle
 
     private function isHeadlessEnabled(): bool
     {
-        $typoScriptSetup = $this->request->getAttribute('frontend.typoscript')->getSetupArray();
-
-        return (bool)($typoScriptSetup['plugin.']['tx_headless.']['staticTemplate'] ?? false);
+        return GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST'])->isEnabled();
     }
 }

--- a/Classes/XClass/Controller/PreviewController.php
+++ b/Classes/XClass/Controller/PreviewController.php
@@ -25,11 +25,6 @@ class PreviewController extends \TYPO3\CMS\Workspaces\Controller\PreviewControll
     protected function generateUrl(Site $site, int $pageUid, array $parameters): string
     {
         $url = (string)$site->getRouter()->generateUri($pageUid, $parameters);
-
-        if ($site->getConfiguration()['headless'] ?? false) {
-            return GeneralUtility::makeInstance(UrlUtility::class)->getFrontendUrlForPage($url, $pageUid);
-        }
-
-        return $url;
+        return GeneralUtility::makeInstance(UrlUtility::class)->getFrontendUrlForPage($url, $pageUid);
     }
 }

--- a/Classes/XClass/ImageService.php
+++ b/Classes/XClass/ImageService.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\XClass;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\ApplicationType;
@@ -29,8 +30,12 @@ class ImageService extends \TYPO3\CMS\Extbase\Service\ImageService
      */
     protected function getImageFromSourceString(string $src, bool $treatIdAsReference): ?FileInterface
     {
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST']);
+
         if (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
-            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()) {
+            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()
+            && $headlessMode->isEnabled()
+        ) {
             $urlUtility = GeneralUtility::makeInstance(UrlUtility::class);
             $baseUriForProxy = $urlUtility->getProxyUrl();
 

--- a/Classes/XClass/Preview/PreviewUriBuilder.php
+++ b/Classes/XClass/Preview/PreviewUriBuilder.php
@@ -46,18 +46,9 @@ class PreviewUriBuilder extends \TYPO3\CMS\Workspaces\Preview\PreviewUriBuilder
                 $language = $site->getDefaultLanguage();
             }
 
-            return $this->prepareHeadlessUrl((string)$site->getRouter()->generateUri($uid, ['ADMCMD_prev' => $previewKeyword, '_language' => $language], ''), $uid, $site->getConfiguration()['headless'] ?? false);
+            return GeneralUtility::makeInstance(UrlUtility::class)->getFrontendUrlForPage((string)$site->getRouter()->generateUri($uid, ['ADMCMD_prev' => $previewKeyword, '_language' => $language], ''), $uid);
         } catch (SiteNotFoundException | InvalidRouteArgumentsException $e) {
             throw new UnableToLinkToPageException('The page ' . $uid . ' had no proper connection to a site, no link could be built.', 1559794916);
         }
-    }
-
-    protected function prepareHeadlessUrl(string $url, int $pageUid, bool $headlessMode): string
-    {
-        if ($headlessMode) {
-            return GeneralUtility::makeInstance(UrlUtility::class)->getFrontendUrlForPage($url, $pageUid);
-        }
-
-        return $url;
     }
 }

--- a/Classes/XClass/ResourceLocalDriver.php
+++ b/Classes/XClass/ResourceLocalDriver.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\XClass;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\ApplicationType;
@@ -25,8 +26,11 @@ class ResourceLocalDriver extends LocalDriver
 {
     protected function determineBaseUrl(): void
     {
-        if (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
-            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend()) {
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST']);
+
+        if ((($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
+            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend()) ||
+            !$headlessMode->isEnabled()) {
             parent::determineBaseUrl();
 
             return;

--- a/Classes/XClass/TemplateView.php
+++ b/Classes/XClass/TemplateView.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\XClass;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 
@@ -24,7 +26,9 @@ class TemplateView extends \TYPO3\CMS\Fluid\View\TemplateView
 {
     public function render($actionName = null)
     {
-        if (!ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()) {
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST']);
+
+        if (!ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend() || !$headlessMode->isEnabled()) {
             return parent::render($actionName);
         }
 

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -8,6 +8,7 @@
  */
 
 use FriendsOfTYPO3\Headless\Middleware\ElementBodyResponseMiddleware;
+use FriendsOfTYPO3\Headless\Middleware\HeadlessModeSetter;
 use FriendsOfTYPO3\Headless\Middleware\RedirectHandler;
 use FriendsOfTYPO3\Headless\Middleware\ShortcutAndMountPointRedirect;
 use FriendsOfTYPO3\Headless\Middleware\SiteBaseRedirectResolver;
@@ -25,6 +26,12 @@ return (static function (): array {
                     'typo3/cms-frontend/content-length-headers',
                 ],
                 'target' => UserIntMiddleware::class,
+            ],
+            'headless/mode-setter' => [
+                'before' => [
+                    'typo3/cms-frontend/base-redirect-resolver',
+                ],
+                'target' => HeadlessModeSetter::class,
             ],
         ],
     ];

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -28,7 +28,6 @@ use FriendsOfTYPO3\Headless\Form\Service\FormTranslationService;
 use FriendsOfTYPO3\Headless\Utility\HeadlessFrontendUrlInterface;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use FriendsOfTYPO3\Headless\XClass\TemplateView;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -37,7 +36,7 @@ use TYPO3\CMS\FrontendLogin\Controller\LoginController;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
-return static function (ContainerConfigurator $configurator, ContainerBuilder $containerBuilder): void {
+return static function (ContainerConfigurator $configurator): void {
     $services = $configurator->services()
         ->defaults()
         ->autoconfigure()

--- a/Configuration/SiteConfiguration/Overrides/site.php
+++ b/Configuration/SiteConfiguration/Overrides/site.php
@@ -7,6 +7,8 @@
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -22,9 +24,23 @@ $tempColumns = [
             'placeholder' => 'http://www.domain.local',
         ],
     ],
+    'headless' => [
+        'label' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.headless.label',
+        'description' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.headless.description',
+        'config' => [
+            'type' => 'select',
+            'renderType' => 'selectSingle',
+            'default' => HeadlessMode::NONE,
+            'items' => [
+                ['LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.headless.none', HeadlessMode::NONE],
+                ['LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.headless.full', HeadlessMode::FULL],
+                ['LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.headless.mixed', HeadlessMode::MIXED],
+            ],
+        ],
+    ],
 ];
 
-$replaceShowItem = 'base, frontendBase, ';
+$replaceShowItem = 'base, frontendBase, headless,';
 
 if ($features->isFeatureEnabled('headless.storageProxy')) {
     $tempColumns['frontendApiProxy'] = [

--- a/Configuration/SiteConfiguration/Overrides/site_base_variant.php
+++ b/Configuration/SiteConfiguration/Overrides/site_base_variant.php
@@ -24,7 +24,7 @@ $tempColumns = [
     ],
 ];
 
-$replaceShowItem = 'base, frontendBase, ';
+$replaceShowItem = 'base, frontendBase,';
 
 if ($features->isFeatureEnabled('headless.storageProxy')) {
     $tempColumns['frontendApiProxy'] = [

--- a/Configuration/TypoScript/Configuration/FeLogin.typoscript
+++ b/Configuration/TypoScript/Configuration/FeLogin.typoscript
@@ -10,10 +10,3 @@ initialData.10.fields.user.fields {
     logged = BOOL
     logged.value = 0
 }
-
-[frontend.user.isLoggedIn]
-    initialData.10.fields.user.fields {
-        logged = BOOL
-        logged.value = 1
-    }
-[global]

--- a/Configuration/TypoScript/LoggedUser/FeLogin.typoscript
+++ b/Configuration/TypoScript/LoggedUser/FeLogin.typoscript
@@ -1,0 +1,6 @@
+[frontend.user.isLoggedIn]
+    initialData.10.fields.user.fields {
+        logged = BOOL
+        logged.value = 1
+    }
+[END]

--- a/Configuration/TypoScript/Mixed/setup.typoscript
+++ b/Configuration/TypoScript/Mixed/setup.typoscript
@@ -1,0 +1,21 @@
+plugin.tx_headless {
+    # Do not remove this!
+    # This will indicate, that the static typoscript for EXT:headless was loaded
+    staticTemplate = 1
+}
+
+[traverse(request.getHeaders(), 'accept')[0] == 'application/json']
+    ## Include page
+    @import "EXT:headless/Configuration/TypoScript/Page/*.typoscript"
+    ## Include content elements
+    @import "EXT:headless/Configuration/TypoScript/ContentElement/*.typoscript"
+    ## Include configuration
+    @import "EXT:headless/Configuration/TypoScript/Configuration/*.typoscript"
+[END]
+
+[traverse(request.getHeaders(), 'accept')[0] == 'application/json' && frontend.user.isLoggedIn]
+    initialData.10.fields.user.fields {
+        logged = BOOL
+        logged.value = 1
+    }
+[END]

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -12,3 +12,4 @@ plugin.tx_headless {
 @import "EXT:headless/Configuration/TypoScript/ContentElement/*.typoscript"
 ## Include configuration
 @import "EXT:headless/Configuration/TypoScript/Configuration/*.typoscript"
+@import "EXT:headless/Configuration/TypoScript/Configuration/LoggedUser/FeLogin.typoscript"

--- a/Resources/Private/Language/locallang_siteconfiguration.xlf
+++ b/Resources/Private/Language/locallang_siteconfiguration.xlf
@@ -55,6 +55,24 @@
             <trans-unit id="siteBaseVariant.columns.frontendFileApi.description" resname="siteBaseVariant.columns.frontendFileApi.description">
                 <source>Main URL to for proxy API files</source>
             </trans-unit>
+            <trans-unit approved="yes" id="site.columns.headless.label">
+                <source>Headless mode</source>
+            </trans-unit>
+            <trans-unit approved="yes" id="site.columns.headless.description">
+                <source>How site should behave in headless context</source>
+            </trans-unit>
+            <trans-unit approved="yes" id="mode">
+                <source>Headless mode</source>
+            </trans-unit>
+            <trans-unit approved="yes" id="site.headless.none">
+                <source>Headless disabled</source>
+            </trans-unit>
+            <trans-unit approved="yes" id="site.headless.full">
+                <source>Full headless mode</source>
+            </trans-unit>
+            <trans-unit approved="yes" id="site.headless.mixed">
+                <source>Mixed headless/fluid mode</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Tests/Unit/DataProcessing/RootSiteProcessing/DomainSchemaTest.php
+++ b/Tests/Unit/DataProcessing/RootSiteProcessing/DomainSchemaTest.php
@@ -13,6 +13,8 @@ namespace FriendsOfTYPO3\Headless\Tests\Unit\DataProcessing\RootSiteProcessing;
 
 use FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\DomainSchema;
 use FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\SiteProvider;
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -139,8 +141,9 @@ class DomainSchemaTest extends UnitTestCase
 
         $siteFinder->getSiteByPageId(Argument::is(1))->willReturn($site);
         $dummyRequest = (new ServerRequest())->withAttribute('site', $site);
+        $dummyRequest = $dummyRequest->withAttribute('headless', new Headless());
 
-        return new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), $dummyRequest);
+        return new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), $dummyRequest, (new HeadlessMode())->withRequest($dummyRequest));
     }
 
     protected function getSiteWithBase(UriInterface $uri, $withLanguage = null)

--- a/Tests/Unit/Event/Listener/RedirectUrlAdditionalParamsListenerTest.php
+++ b/Tests/Unit/Event/Listener/RedirectUrlAdditionalParamsListenerTest.php
@@ -13,6 +13,8 @@ namespace FriendsOfTYPO3\Headless\Tests\Unit\Event\Listener;
 
 use FriendsOfTYPO3\Headless\Event\Listener\RedirectUrlAdditionalParamsListener;
 use FriendsOfTYPO3\Headless\Event\RedirectUrlEvent;
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -244,6 +246,6 @@ class RedirectUrlAdditionalParamsListenerTest extends UnitTestCase
 
         $siteFinder->getSiteByPageId(Argument::is(1))->willReturn($site);
 
-        return new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        return new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, (new HeadlessMode())->withRequest((new ServerRequest())->withAttribute('headless', new Headless())));
     }
 }

--- a/Tests/Unit/Middleware/ElementBodyResponseMiddlewareTest.php
+++ b/Tests/Unit/Middleware/ElementBodyResponseMiddlewareTest.php
@@ -13,6 +13,8 @@ namespace FriendsOfTYPO3\Headless\Tests\Unit\Middleware;
 
 use FriendsOfTYPO3\Headless\Json\JsonEncoder;
 use FriendsOfTYPO3\Headless\Middleware\ElementBodyResponseMiddleware;
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Prophecy\PhpUnit\ProphecyTrait;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -29,7 +31,7 @@ class ElementBodyResponseMiddlewareTest extends UnitTestCase
      */
     public function processTest()
     {
-        $middleware = new ElementBodyResponseMiddleware(new JsonEncoder());
+        $middleware = new ElementBodyResponseMiddleware(new JsonEncoder(), new HeadlessMode());
 
         $responseArray = ['content' => ['colPos1' => [['id' => 1]]]];
         $result = json_encode($responseArray['content']['colPos1'][0]);
@@ -120,7 +122,7 @@ class ElementBodyResponseMiddlewareTest extends UnitTestCase
             )
         );
 
-        $middleware = new ElementBodyResponseMiddleware(new JsonEncoder());
+        $middleware = new ElementBodyResponseMiddleware(new JsonEncoder(), new HeadlessMode());
 
         $responseArray = ['content' => ['colPos2' => null, 'colPos1' => [['id' => 1]]]];
         $result = json_encode($responseArray['content']['colPos1'][0]);
@@ -176,6 +178,8 @@ class ElementBodyResponseMiddlewareTest extends UnitTestCase
             $request = $request->withMethod($withMethod);
         }
 
+        $request = $request->withAttribute('headless', new Headless());
+
         if ($withSite) {
             $site = $this->prophesize(Site::class);
             $site->getConfiguration()->willReturn([
@@ -183,6 +187,7 @@ class ElementBodyResponseMiddlewareTest extends UnitTestCase
             ]);
 
             $request = $request->withAttribute('site', $site->reveal());
+            $request = $request->withAttribute('headless', new Headless($headless ? HeadlessMode::FULL : HeadlessMode::NONE));
         }
 
         return $request;

--- a/Tests/Unit/Middleware/HeadlessModeSetterTest.php
+++ b/Tests/Unit/Middleware/HeadlessModeSetterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Tests\Unit\Middleware;
+
+use FriendsOfTYPO3\Headless\Middleware\HeadlessModeSetter;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Frontend\Http\RequestHandler;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class HeadlessModeSetterTest extends UnitTestCase
+{
+    public function test(): void
+    {
+        $middleware = new HeadlessModeSetter();
+        $request = new ServerRequest();
+        $request = $request->withAttribute('site', new Site('test', 1, ['headless' => true]));
+        $handler = $this->createMock(RequestHandler::class);
+        $handler->method('handle')->willReturn(new Response());
+
+        $middleware->process($request, $handler);
+
+        self::assertTrue($GLOBALS['TYPO3_REQUEST']->getAttribute('headless')->getMode() === HeadlessMode::FULL);
+    }
+    public function testNotSet(): void
+    {
+        $middleware = new HeadlessModeSetter();
+        $request = new ServerRequest();
+        $handler = $this->createMock(RequestHandler::class);
+        $handler->method('handle')->willReturn(new Response());
+
+        $middleware->process($request, $handler);
+
+        self::assertTrue($GLOBALS['TYPO3_REQUEST']->getAttribute('headless')->getMode() === HeadlessMode::NONE);
+    }
+}

--- a/Tests/Unit/Middleware/UserIntMiddlewareTest.php
+++ b/Tests/Unit/Middleware/UserIntMiddlewareTest.php
@@ -12,12 +12,12 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Headless\Tests\Unit\Middleware;
 
 use FriendsOfTYPO3\Headless\Middleware\UserIntMiddleware;
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\HeadlessUserInt;
 use Prophecy\PhpUnit\ProphecyTrait;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\ServerRequest;
-use TYPO3\CMS\Core\TypoScript\TemplateService;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Http\RequestHandler;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -30,10 +30,11 @@ class UserIntMiddlewareTest extends UnitTestCase
      */
     public function processTest()
     {
-        $middleware = new UserIntMiddleware(new HeadlessUserInt());
+        $middleware = new UserIntMiddleware(new HeadlessUserInt(), new HeadlessMode());
 
         $request = new ServerRequest();
-        $request = $request->withAttribute('frontend.controller', $this->getTsfeProphecy()->reveal());
+
+        $request = $request->withAttribute('headless', new Headless(HeadlessMode::FULL));
 
         $intScript = '<!--INT_SCRIPT.d53df2a300e62171a7b4882c4b88a153-->';
         $responseString = HeadlessUserInt::NESTED . '_START<<' . $intScript . '>>' . HeadlessUserInt::NESTED . '_END';
@@ -47,10 +48,10 @@ class UserIntMiddlewareTest extends UnitTestCase
             )->getBody()->__toString()
         );
 
-        $middleware = new UserIntMiddleware(new HeadlessUserInt());
+        $middleware = new UserIntMiddleware(new HeadlessUserInt(), new HeadlessMode());
 
         $request = new ServerRequest();
-        $request = $request->withAttribute('frontend.controller', $this->getTsfeProphecy('0')->reveal());
+        $request = $request->withAttribute('headless', new Headless());
 
         self::assertEquals(
             $responseString,
@@ -60,12 +61,13 @@ class UserIntMiddlewareTest extends UnitTestCase
             )->getBody()->__toString()
         );
 
-        $GLOBALS['TSFE'] = $this->getTsfeProphecy('0')->reveal();
+        $request = new ServerRequest();
+        $request = $request->withAttribute('headless', new Headless());
 
         self::assertEquals(
             $responseString,
             $middleware->process(
-                new ServerRequest(),
+                $request,
                 $this->getMockHandlerWithResponse($response)
             )->getBody()->__toString()
         );
@@ -76,19 +78,5 @@ class UserIntMiddlewareTest extends UnitTestCase
         $handler = $this->createPartialMock(RequestHandler::class, ['handle']);
         $handler->method('handle')->willReturn($response);
         return $handler;
-    }
-
-    protected function getTsfeProphecy(string $staticTemplate = '1')
-    {
-        $setup = [];
-        $setup['plugin.']['tx_headless.']['staticTemplate'] = $staticTemplate;
-
-        $tmpl = $this->prophesize(TemplateService::class);
-        $tmpl->setup = $setup;
-
-        $tsfe = $this->prophesize(TypoScriptFrontendController::class);
-        $tsfe->tmpl = $tmpl->reveal();
-
-        return $tsfe;
     }
 }

--- a/Tests/Unit/Utility/HeadlessModeTest.php
+++ b/Tests/Unit/Utility/HeadlessModeTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace FriendsOfTYPO3\Headless\Tests\Unit\Utility;
+
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Http\ServerRequest;
+
+class HeadlessModeTest extends TestCase
+{
+    public function testMixedModeWithoutHeader(): void
+    {
+        $mode = new HeadlessMode();
+
+        $request =  new ServerRequest();
+        $request = $request->withAttribute('headless', new Headless(HeadlessMode::MIXED));
+
+        $mode = $mode->withRequest($request);
+
+        self::assertFalse($mode->isEnabled());
+    }
+
+    public function testMixedModeWithHeader(): void
+    {
+        $mode = new HeadlessMode();
+
+        $request =  new ServerRequest();
+        $request = $request->withHeader('Accept', 'application/json');
+        $request = $request->withAttribute('headless', new Headless(HeadlessMode::MIXED));
+
+        $mode = $mode->withRequest($request);
+
+        self::assertTrue($mode->isEnabled());
+    }
+
+    public function testDisabled(): void
+    {
+        $mode = new HeadlessMode();
+
+        $request =  new ServerRequest();
+        $request = $request->withHeader('Accept', 'application/json');
+        $request = $request->withAttribute('headless', new Headless(HeadlessMode::NONE));
+
+        $mode = $mode->withRequest($request);
+
+        self::assertFalse($mode->isEnabled());
+    }
+
+    public function testNotSet(): void
+    {
+        $mode = new HeadlessMode();
+
+        $request =  new ServerRequest();
+        $request = $request->withHeader('Accept', 'application/json');
+
+        $mode = $mode->withRequest($request);
+
+        self::assertFalse($mode->isEnabled());
+        // without passed request
+        self::assertFalse((new HeadlessMode())->isEnabled());
+    }
+
+    public function testFullMode(): void
+    {
+        $mode = new HeadlessMode();
+
+        $request = new ServerRequest();
+        $request = $request->withAttribute('headless', new Headless(HeadlessMode::FULL));
+
+        $mode = $mode->withRequest($request);
+
+        self::assertTrue($mode->isEnabled());
+    }
+}

--- a/Tests/Unit/Utility/UrlUtilityTest.php
+++ b/Tests/Unit/Utility/UrlUtilityTest.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\Tests\Unit\Utility;
 
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -30,6 +32,8 @@ class UrlUtilityTest extends UnitTestCase
 
     public function testFrontendUrls(): void
     {
+        $headlessMode = $this->createHeadlessMode();
+
         $site = $this->prophesize(Site::class);
         $site->getConfiguration()->shouldBeCalled(3)->willReturn([
             'base' => 'https://www.typo3.org',
@@ -68,7 +72,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame('https://test-frontend.tld', $urlUtility->getFrontendUrl());
@@ -82,7 +86,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame('https://test-frontend2.tld', $urlUtility->getFrontendUrl());
@@ -97,7 +101,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame('https://test-frontend3.tld', $urlUtility->getFrontendUrl());
@@ -134,7 +138,9 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::containingString('Development'))->willReturn(true);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $headlessMode = $this->createHeadlessMode();
+
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame('https://test-frontend.tld', $urlUtility->getFrontendUrl());
@@ -146,7 +152,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::containingString('Development'))->willReturn(false);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame('https://www.typo3.org', $urlUtility->getFrontendUrl());
@@ -157,6 +163,8 @@ class UrlUtilityTest extends UnitTestCase
 
     public function testOptimizedUrlsForFrontendApp(): void
     {
+        $headlessMode = $this->createHeadlessMode();
+
         $site = $this->prophesize(Site::class);
         $site->getConfiguration()->shouldBeCalled(2)->willReturn([
             'base' => 'https://www.typo3.org',
@@ -185,7 +193,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         // same page, so we make it relative
@@ -214,7 +222,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         // same page, so we make it relative
@@ -251,6 +259,8 @@ class UrlUtilityTest extends UnitTestCase
 
     public function testLanguageResolver(): void
     {
+        $headlessMode = $this->createHeadlessMode();
+
         $site = $this->prophesize(Site::class);
         $site->getConfiguration()->shouldBeCalled(2)->willReturn([
             'base' => 'https://www.typo3.org',
@@ -279,7 +289,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
         $urlUtility = $urlUtility->withLanguage(new SiteLanguage(0, 'en', new Uri('/'), [
             'title' =>  'English',
@@ -353,7 +363,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
         $urlUtility = $urlUtility->withLanguage(new SiteLanguage(0, 'en', new Uri('/'), [
             'title' =>  'English',
@@ -391,6 +401,7 @@ class UrlUtilityTest extends UnitTestCase
     public function testFrontendUrlForPage(): void
     {
         $site = $this->prophesize(Site::class);
+        $site->getBase()->shouldBeCalled(2)->willReturn(new Uri('https://test-backend-api.tld'));
         $site->getConfiguration()->shouldBeCalled(2)->willReturn([
             'base' => 'https://www.typo3.org',
             'languages' => [],
@@ -399,11 +410,11 @@ class UrlUtilityTest extends UnitTestCase
                     'base' => 'https://test-backend-api.tld',
                     'condition' => 'applicationContext == "Development"',
                     'frontendBase' => 'https://test-frontend.tld',
-                    'frontendApiProxy' => 'https://test-frontend-api.tld/headless',
+                    'frontendApiProxy' => 'https://test-frontend.tld/headless',
                     'frontendFileApi' => 'https://test-frontend-api.tld/headless/fileadmin',
                 ],
             ],
-            'headless' => false,
+            'headless' => 0,
         ]);
 
         $resolver = $this->prophesize(Resolver::class);
@@ -412,7 +423,8 @@ class UrlUtilityTest extends UnitTestCase
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalled(2)->willReturn($site->reveal());
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $headlessMode = $this->createHeadlessMode(HeadlessMode::NONE);
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         // flag is not existing/disabled
@@ -421,35 +433,13 @@ class UrlUtilityTest extends UnitTestCase
             $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld/test-page', 1)
         );
 
-        // flag is enabled
-        $site = $this->prophesize(Site::class);
-        $site->getConfiguration()->shouldBeCalled(2)->willReturn([
-            'base' => 'https://www.typo3.org',
-            'languages' => [],
-            'baseVariants' => [
-                [
-                    'base' => 'https://test-backend-api23.tld',
-                    'condition' => 'applicationContext == "Development"',
-                    'frontendBase' => 'https://test-frontend23.tld',
-                    'frontendApiProxy' => 'https://test-frontend-api.tld/headless',
-                    'frontendFileApi' => 'https://test-frontend-api.tld/headless/fileadmin',
-                ],
-            ],
-            'headless' => true,
-        ]);
+        $headlessMode = $this->createHeadlessMode(HeadlessMode::FULL);
 
-        $uri = new Uri('https://test-backend-api23.tld');
-
-        $site->getBase()->shouldBeCalled(2)->willReturn($uri);
-
-        $siteFinder = $this->prophesize(SiteFinder::class);
-        $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalled(1)->willReturn($site->reveal());
-
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
-
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
+        $urlUtility = $urlUtility->withSite($site->reveal());
         self::assertSame(
-            'https://test-frontend23.tld/test-page',
-            $urlUtility->getFrontendUrlForPage('https://test-backend-api23.tld/test-page', 1)
+            'https://test-frontend.tld/test-page',
+            $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld/test-page', 1)
         );
     }
 
@@ -479,7 +469,9 @@ class UrlUtilityTest extends UnitTestCase
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalledOnce()->willReturn($site->reveal());
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $headlessMode = $this->createHeadlessMode();
+
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame(
@@ -491,6 +483,7 @@ class UrlUtilityTest extends UnitTestCase
     public function testFrontendUrlForPageWithPortsOnFrontendSide(): void
     {
         $site = $this->prophesize(Site::class);
+        $site->getBase()->willReturn(new Uri('https://test-backend-api.tld'));
         $site->getConfiguration()->shouldBeCalled(2)->willReturn([
             'base' => 'https://www.typo3.org',
             'languages' => [],
@@ -512,71 +505,8 @@ class UrlUtilityTest extends UnitTestCase
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalled(2)->willReturn($site->reveal());
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
-        $urlUtility = $urlUtility->withSite($site->reveal());
-
-        // flag is not existing/disabled
-        self::assertSame(
-            'https://test-backend-api.tld/test-page',
-            $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld/test-page', 1)
-        );
-
-        $site = $this->prophesize(Site::class);
-        $site->getConfiguration()->shouldBeCalled(2)->willReturn([
-            'base' => 'https://www.typo3.org',
-            'languages' => [],
-            'baseVariants' => [
-                [
-                    'base' => 'https://test-backend-api.tld',
-                    'condition' => 'applicationContext == "Development"',
-                    'frontendBase' => 'https://test-frontend.tld:3000',
-                    'frontendApiProxy' => 'https://test-frontend-api.tld/headless',
-                    'frontendFileApi' => 'https://test-frontend-api.tld/headless/fileadmin',
-                ],
-            ],
-            'headless' => true,
-        ]);
-
-        $uri = new Uri('https://test-backend-api.tld');
-
-        $site->getBase()->shouldBeCalled(2)->willReturn($uri);
-
-        $siteFinder = $this->prophesize(SiteFinder::class);
-        $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalled(2)->willReturn($site->reveal());
-
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
-
-        self::assertSame(
-            'https://test-frontend.tld:3000/test-page',
-            $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld/test-page', 1)
-        );
-    }
-
-    public function testFrontendUrlForPageWithPortsOnBothSides(): void
-    {
-        $site = $this->prophesize(Site::class);
-        $site->getConfiguration()->shouldBeCalled(2)->willReturn([
-            'base' => 'https://www.typo3.org',
-            'languages' => [],
-            'baseVariants' => [
-                [
-                    'base' => 'https://test-backend-api.tld:8000',
-                    'condition' => 'applicationContext == "Development"',
-                    'frontendBase' => 'https://test-frontend.tld:3000',
-                    'frontendApiProxy' => 'https://test-frontend-api.tld/headless',
-                    'frontendFileApi' => 'https://test-frontend-api.tld/headless/fileadmin',
-                ],
-            ],
-            'headless' => false,
-        ]);
-
-        $resolver = $this->prophesize(Resolver::class);
-        $resolver->evaluate(Argument::any())->willReturn(true);
-
-        $siteFinder = $this->prophesize(SiteFinder::class);
-        $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalled(2)->willReturn($site->reveal());
-
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $headlessMode = $this->createHeadlessMode(HeadlessMode::NONE);
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         // flag is not existing/disabled
@@ -586,8 +516,21 @@ class UrlUtilityTest extends UnitTestCase
         );
 
         // flag is enabled
+        $headlessMode = $this->createHeadlessMode();
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
+        $urlUtility = $urlUtility->withSite($site->reveal());
+        self::assertSame(
+            'https://test-frontend.tld:3000/test-page',
+            $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld/test-page', 1)
+        );
+    }
+
+    public function testFrontendUrlForPageWithPortsOnBothSides(): void
+    {
+        $headlessMode = $this->createHeadlessMode(HeadlessMode::NONE);
         $site = $this->prophesize(Site::class);
-        $site->getConfiguration()->willReturn([
+        $site->getBase()->willReturn(new Uri('https://test-backend-api.tld:8000'));
+        $site->getConfiguration()->shouldBeCalled(2)->willReturn([
             'base' => 'https://www.typo3.org',
             'languages' => [],
             'baseVariants' => [
@@ -599,18 +542,28 @@ class UrlUtilityTest extends UnitTestCase
                     'frontendFileApi' => 'https://test-frontend-api.tld/headless/fileadmin',
                 ],
             ],
-            'headless' => true,
+            'headless' => false,
         ]);
 
-        $uri = new Uri('https://test-backend-api.tld:8000');
-
-        $site->getBase()->shouldBeCalled(2)->willReturn($uri);
+        $resolver = $this->prophesize(Resolver::class);
+        $resolver->evaluate(Argument::any())->willReturn(true);
 
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalled(2)->willReturn($site->reveal());
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
+        $urlUtility = $urlUtility->withSite($site->reveal());
 
+        // flag is not existing/disabled
+        self::assertSame(
+            'https://test-backend-api.tld/test-page',
+            $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld/test-page', 1)
+        );
+
+        // flag is enabled
+        $headlessMode = $this->createHeadlessMode();
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
+        $urlUtility = $urlUtility->withSite($site->reveal());
         self::assertSame(
             'https://test-frontend.tld:3000/test-page',
             $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld:8000/test-page', 1)
@@ -619,9 +572,13 @@ class UrlUtilityTest extends UnitTestCase
 
     public function testEdgeCases()
     {
+        $headlessMode = $this->createHeadlessMode();
+
         $site = $this->createMockSite('https://test-backend-api.tld:8000');
         $request = $this->prophesize(ServerRequest::class);
         $request->getAttribute(Argument::is('site'))->willReturn($site);
+        $request->getAttribute(Argument::is('headless'))->willReturn(new Headless(HeadlessMode::FULL));
+        $request->getHeader(Argument::is('Accept'))->willReturn([]);
         $request->getAttribute(Argument::is('language'))->willReturn(null);
 
         $resolver = $this->prophesize(Resolver::class);
@@ -629,7 +586,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalledOnce()->willReturn($site);
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), $request->reveal(), null, $headlessMode);
 
         self::assertSame(
             'https://test-backend-api.tld:8000/test-page',
@@ -648,7 +605,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->createPartialMock(Resolver::class, ['evaluate']);
         $resolver->method('evaluate')->willThrowException(new SyntaxError('test'));
 
-        $urlUtility = new UrlUtility(null, $resolver, $siteFinder, $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver, $siteFinder, $request->reveal(), $headlessMode);
         self::assertSame('', $urlUtility->getFrontendUrl());
 
         $urlUtility = $urlUtility->withSite($this->createMockSite('https://test-frontend.tld', '', []));
@@ -682,7 +639,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::any())->willReturn(true);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal(), $headlessMode);
         self::assertSame('https://test-frontend-from-lang.tld', $urlUtility->getFrontendUrl());
 
         $request = $this->prophesize(ServerRequest::class);
@@ -704,7 +661,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::any())->willReturn(true);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal(), $headlessMode);
         self::assertSame('', $urlUtility->getFrontendUrl());
 
         // configuration on language lvl without variants
@@ -730,7 +687,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::any())->willReturn(true);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal(), $headlessMode);
         self::assertSame('https://frontend-domain-from-lang.tld', $urlUtility->getFrontendUrl());
         self::assertSame('https://frontend-domain-from-lang.tld/headless', $urlUtility->getProxyUrl());
         self::assertSame('https://frontend-domain-from-lang.tld/headless/fileadmin', $urlUtility->getStorageProxyUrl());
@@ -768,7 +725,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::any())->willReturn(true);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal(), $headlessMode);
         self::assertSame('https://test-frontend-from-when-develop-lang.tld', $urlUtility->getFrontendUrl());
         self::assertSame('https://test-frontend-from-when-develop-lang.tld/headless', $urlUtility->getProxyUrl());
         self::assertSame('https://test-frontend-from-when-develop-lang.tld/headless/fileadmin', $urlUtility->getStorageProxyUrl());
@@ -801,7 +758,7 @@ class UrlUtilityTest extends UnitTestCase
             ],
         ]));
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder);
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, null, $headlessMode);
         $urlUtilityWithRequest = $urlUtility->withRequest($manualRequest->reveal());
         self::assertSame('https://test-frontend-from-from-request-lang.tld', $urlUtilityWithRequest->getFrontendUrl());
         self::assertSame('https://test-frontend-from-from-request-lang.tld/headless', $urlUtilityWithRequest->getProxyUrl());
@@ -832,5 +789,15 @@ class UrlUtilityTest extends UnitTestCase
         $uri = new Uri($backendUrl);
         $site->getBase()->willReturn($uri);
         return $site->reveal();
+    }
+
+    private function createHeadlessMode(int $mode =  HeadlessMode::FULL): HeadlessMode
+    {
+        $headlessMode = new HeadlessMode();
+
+        $request =  new ServerRequest();
+        $request = $request->withAttribute('headless', new Headless($mode));
+
+        return $headlessMode->withRequest($request);
     }
 }

--- a/Tests/Unit/XClass/Fixtures/Templates/Default/DefaultException.php
+++ b/Tests/Unit/XClass/Fixtures/Templates/Default/DefaultException.php
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+throw new RuntimeException('Example exception in template');


### PR DESCRIPTION
[FEATURE] Introduce mixed mode for headless

Patch introduces new way for checking if we are in headless mode, you can set not enabled, mixed mode (fluid & headless at the same time), or full headless mode.

To configure headless mode, please use site configuration flag, for example:
`
   'headless': 0|1|2
`
Legacy flag (true|false) is respected, but please migrate to integer notation

Possible options:
 0 (old: false) = headless disabled for site in TYPO3 instance
 1 (old: true) = headless fully enabled site in TYPO3 instance
 2 = headless in mixed mode (fluid & json API in one site in TYPO3 instance)

Values 0 (old: false) or 1 (old: true) inform extension to fully disable/enable headless for particular site.

To enable mixed mode for chosen site in TYPO3 you need to:
- In typoscript template for site, you have to load "`Headless - Mixed mode JSON response`" setup file instead of default headless one.
- set `headless` flag to value of `2` site configuration's file or configure flag via editor in Site's management backend

Mixed mode flag (value of `2`) inform EXT:headless extension to additionally check for `Accept` header with value `application/json` when processing request to the particular site in TYPO3 instance.

In case of request without `Accept` header or `Accept` with different value than `application/json` TYPO3 will respond with HTML content (standard TYPO3's response)
In case of request with header `Accept` match value of `application/json`, TYPO3 will respond with JSON response.

 resolves #94 