### PR TITLE
[FEATURE] Introduce mixed mode for headless

### DIFF
--- a/Classes/DataProcessing/DatabaseQueryProcessor.php
+++ b/Classes/DataProcessing/DatabaseQueryProcessor.php
@@ -79,7 +79,7 @@ class DatabaseQueryProcessor implements DataProcessorInterface
      */
     public function process(ContentObjectRenderer $cObj, array $contentObjectConfiguration, array $processorConfiguration, array $processedData): array
     {
-        if (isset($processorConfiguration['if.']) && ! $cObj->checkIf($processorConfiguration['if.'])) {
+        if (isset($processorConfiguration['if.']) && !$cObj->checkIf($processorConfiguration['if.'])) {
             return $processedData;
         }
 

--- a/Classes/DataProcessing/GalleryProcessor.php
+++ b/Classes/DataProcessing/GalleryProcessor.php
@@ -109,7 +109,7 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
             // Recalculate gallery width
             $this->galleryData['width'] = floor($maximumRowWidth / $mediaScalingCorrection);
 
-            // User entered a predefined width
+        // User entered a predefined width
         } elseif ($this->equalMediaWidth) {
             $mediaScalingCorrection = 1;
 
@@ -133,7 +133,7 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
             // Recalculate gallery width
             $this->galleryData['width'] = floor($totalRowWidth / $mediaScalingCorrection);
 
-            // Automatic setting of width and height
+        // Automatic setting of width and height
         } else {
             $maxMediaWidth = (int)($galleryWidthMinusBorderAndSpacing / $this->galleryData['count']['columns']);
             foreach ($this->fileObjects as $key => $fileObject) {

--- a/Classes/Hooks/FileOrFolderLinkBuilder.php
+++ b/Classes/Hooks/FileOrFolderLinkBuilder.php
@@ -11,7 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\Hooks;
 
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
 use TYPO3\CMS\Frontend\Typolink\UnableToLinkException;
 
@@ -26,14 +27,9 @@ class FileOrFolderLinkBuilder extends \TYPO3\CMS\Frontend\Typolink\FileOrFolderL
      */
     public function build(array &$linkDetails, string $linkText, string $target, array $conf): LinkResultInterface
     {
-        $setup = ($GLOBALS['TSFE'] ?? null) instanceof TypoScriptFrontendController ? $GLOBALS['TSFE']->tmpl->setup : null;
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST']);
 
-        if (
-            array_key_exists('type', $linkDetails)
-            && $linkDetails['type'] === 'file'
-            && isset($setup['plugin.']['tx_headless.']['staticTemplate'])
-            && (bool)$setup['plugin.']['tx_headless.']['staticTemplate'] === true
-        ) {
+        if ($headlessMode->isEnabled()) {
             $conf['forceAbsoluteUrl'] = 1;
         }
 

--- a/Classes/Hooks/TypolinkHook.php
+++ b/Classes/Hooks/TypolinkHook.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\Hooks;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -29,11 +30,9 @@ class TypolinkHook
             return;
         }
 
-        $setup = $GLOBALS['TSFE']->tmpl->setup;
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST']);
 
-        if (!isset($setup['plugin.']['tx_headless.']['staticTemplate'])
-            || (bool)$setup['plugin.']['tx_headless.']['staticTemplate'] === false
-        ) {
+        if (!$headlessMode->isEnabled()) {
             // Just do nothing and don't modify the previously generated typolink when EXT:headless won't be used
             return;
         }

--- a/Classes/Middleware/ElementBodyResponseMiddleware.php
+++ b/Classes/Middleware/ElementBodyResponseMiddleware.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Headless\Middleware;
 
 use FriendsOfTYPO3\Headless\Json\JsonEncoder;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -26,10 +27,12 @@ use function json_decode;
 class ElementBodyResponseMiddleware implements MiddlewareInterface
 {
     private JsonEncoder $jsonEncoder;
+    private HeadlessMode $headlessMode;
 
-    public function __construct(JsonEncoder $jsonEncoder = null)
+    public function __construct(JsonEncoder $jsonEncoder = null, HeadlessMode $headlessMode)
     {
         $this->jsonEncoder = $jsonEncoder;
+        $this->headlessMode = $headlessMode;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -45,9 +48,7 @@ class ElementBodyResponseMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        $siteConf = $request->getAttribute('site')->getConfiguration();
-
-        if (!($siteConf['headless'] ?? false)) {
+        if (!$this->headlessMode->withRequest($request)->isEnabled()) {
             return $response;
         }
 

--- a/Classes/Middleware/HeadlessModeSetter.php
+++ b/Classes/Middleware/HeadlessModeSetter.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Middleware;
+
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Site\Entity\Site;
+
+class HeadlessModeSetter implements MiddlewareInterface
+{
+    public function __construct()
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $mode = HeadlessMode::NONE;
+
+        /**
+         * @var Site $site
+         */
+        $site = $request->getAttribute('site');
+        if ($site) {
+            $mode = (int)($site->getConfiguration()['headless'] ?? HeadlessMode::NONE);
+        }
+
+        $request = $request->withAttribute('headless', new Headless($mode));
+
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+        return $handler->handle($request);
+    }
+}

--- a/Classes/Middleware/RedirectHandler.php
+++ b/Classes/Middleware/RedirectHandler.php
@@ -13,6 +13,7 @@ namespace FriendsOfTYPO3\Headless\Middleware;
 
 use FriendsOfTYPO3\Headless\Event\RedirectUrlEvent;
 use FriendsOfTYPO3\Headless\Utility\HeadlessFrontendUrlInterface;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -31,15 +32,18 @@ final class RedirectHandler extends \TYPO3\CMS\Redirects\Http\Middleware\Redirec
     private EventDispatcherInterface $eventDispatcher;
     private ServerRequestInterface $request;
     private HeadlessFrontendUrlInterface $urlUtility;
+    private HeadlessMode $headlessMode;
 
     public function __construct(
         RedirectService $redirectService,
         HeadlessFrontendUrlInterface $urlUtility,
-        EventDispatcher $eventDispatcher
+        EventDispatcher $eventDispatcher,
+        HeadlessMode $headlessMode
     ) {
         parent::__construct($redirectService);
         $this->urlUtility = $urlUtility;
         $this->eventDispatcher = $eventDispatcher;
+        $this->headlessMode = $headlessMode;
     }
 
     /**
@@ -65,9 +69,7 @@ final class RedirectHandler extends \TYPO3\CMS\Redirects\Http\Middleware\Redirec
             return parent::buildRedirectResponse($uri, $redirectRecord);
         }
 
-        $siteConf = $this->request->getAttribute('site')->getConfiguration();
-
-        if (!($siteConf['headless'] ?? false)) {
+        if (!$this->headlessMode->withRequest($this->request)->isEnabled()) {
             return parent::buildRedirectResponse($uri, $redirectRecord);
         }
 

--- a/Classes/Middleware/ShortcutAndMountPointRedirect.php
+++ b/Classes/Middleware/ShortcutAndMountPointRedirect.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\Middleware;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -28,6 +29,12 @@ use function parse_url;
 class ShortcutAndMountPointRedirect implements MiddlewareInterface
 {
     private ?TypoScriptFrontendController $controller;
+    private HeadlessMode $headlessMode;
+
+    public function __construct(HeadlessMode $headlessMode)
+    {
+        $this->headlessMode = $headlessMode;
+    }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
@@ -121,17 +128,6 @@ class ShortcutAndMountPointRedirect implements MiddlewareInterface
 
     private function isHeadlessEnabled(ServerRequestInterface $request): bool
     {
-        /**
-         * @var Site
-         */
-        $site = $request->getAttribute('site');
-
-        if (!($site instanceof Site)) {
-            return false;
-        }
-
-        $siteConf = $request->getAttribute('site')->getConfiguration();
-
-        return $siteConf['headless'] ?? false;
+        return $this->headlessMode->withRequest($request)->isEnabled();
     }
 }

--- a/Classes/Utility/Headless.php
+++ b/Classes/Utility/Headless.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Utility;
+
+/**
+ * @codeCoverageIgnore
+ */
+final class Headless
+{
+    private int $mode;
+
+    public function __construct(int $mode = HeadlessMode::NONE)
+    {
+        $this->mode = $mode;
+    }
+
+    public function getMode(): int
+    {
+        return $this->mode;
+    }
+}

--- a/Classes/Utility/HeadlessMode.php
+++ b/Classes/Utility/HeadlessMode.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Utility;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class HeadlessMode
+{
+    public const NONE = 0;
+    public const FULL = 1;
+    public const MIXED = 2;
+
+    private ?ServerRequestInterface $request = null;
+
+    public function withRequest(ServerRequestInterface $request): self
+    {
+        $this->request = $request;
+        return $this;
+    }
+    public function isEnabled(): bool
+    {
+        if ($this->request === null) {
+            return false;
+        }
+
+        $headless = $this->request->getAttribute('headless') ?? new Headless();
+
+        if ($headless->getMode() === self::NONE) {
+            return false;
+        }
+
+        return $headless->getMode() === self::FULL ||
+            ($headless->getMode() === self::MIXED && ($this->request->getHeader('Accept')[0] ?? '') === 'application/json');
+    }
+}

--- a/Classes/Utility/UrlUtility.php
+++ b/Classes/Utility/UrlUtility.php
@@ -38,16 +38,19 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
     private SiteFinder $siteFinder;
     private array $conf = [];
     private array $variants = [];
+    private HeadlessMode $headlessMode;
 
     public function __construct(
         ?Features $features = null,
         ?Resolver $resolver = null,
         ?SiteFinder $siteFinder = null,
-        ?ServerRequestInterface $serverRequest = null
+        ?ServerRequestInterface $serverRequest = null,
+        ?HeadlessMode $headlessMode = null
     ) {
         $this->features = $features ?? GeneralUtility::makeInstance(Features::class);
         $this->resolver = $resolver ?? GeneralUtility::makeInstance(Resolver::class, 'site', []);
         $this->siteFinder = $siteFinder ?? GeneralUtility::makeInstance(SiteFinder::class);
+        $this->headlessMode = $headlessMode ?? GeneralUtility::makeInstance(HeadlessMode::class);
         $request = $serverRequest ?? ($GLOBALS['TYPO3_REQUEST'] ?? null);
 
         if ($request instanceof ServerRequestInterface) {
@@ -72,7 +75,7 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
 
     public function getFrontendUrlWithSite($url, SiteInterface $site, string $returnField = 'frontendBase'): string
     {
-        if (!$this->features->isFeatureEnabled('headless.frontendUrls')) {
+        if (!$this->headlessMode->isEnabled()) {
             return $url;
         }
 
@@ -119,7 +122,7 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
     public function getFrontendUrlForPage(string $url, int $pageUid, string $returnField = 'frontendBase'): string
     {
         try {
-            if (!$this->features->isFeatureEnabled('headless.frontendUrls')) {
+            if (!$this->headlessMode->isEnabled()) {
                 return $url;
             }
 
@@ -273,6 +276,8 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
         if ($language instanceof SiteLanguage) {
             $object->handleLanguageConfiguration($language, $object);
         }
+
+        $object->headlessMode = $object->headlessMode->withRequest($request);
 
         return $object;
     }

--- a/Classes/Utility/UrlUtility.php
+++ b/Classes/Utility/UrlUtility.php
@@ -75,18 +75,18 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
 
     public function getFrontendUrlWithSite($url, SiteInterface $site, string $returnField = 'frontendBase'): string
     {
+        $this->handleSiteConfiguration($site, $this);
+
         if (!$this->headlessMode->isEnabled()) {
             return $url;
         }
-
-        $configuration = $site->getConfiguration();
 
         try {
             $base = $site->getBase()->getHost();
             $port = $site->getBase()->getPort();
             $frontendBaseUrl = $this->resolveWithVariants(
-                $configuration[$returnField] ?? '',
-                $configuration['baseVariants'] ?? [],
+                $this->conf[$returnField] ?? '',
+                $this->variants,
                 $returnField
             );
 
@@ -122,10 +122,6 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
     public function getFrontendUrlForPage(string $url, int $pageUid, string $returnField = 'frontendBase'): string
     {
         try {
-            if (!$this->headlessMode->isEnabled()) {
-                return $url;
-            }
-
             return $this->getFrontendUrlWithSite(
                 $url,
                 $this->siteFinder->getSiteByPageId($pageUid),
@@ -208,7 +204,6 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
         string $returnField = 'frontendBase'
     ): string {
         $frontendUrl = rtrim($frontendUrl, '/');
-
         if ($variants === []) {
             return $frontendUrl;
         }
@@ -268,6 +263,7 @@ class UrlUtility implements LoggerAwareInterface, HeadlessFrontendUrlInterface
     private function extractConfigurationFromRequest(ServerRequestInterface $request, HeadlessFrontendUrlInterface $object): HeadlessFrontendUrlInterface
     {
         $site = $request->getAttribute('site');
+
         if ($site instanceof Site) {
             $object->handleSiteConfiguration($site, $object);
         }

--- a/Classes/XClass/Controller/FormFrontendController.php
+++ b/Classes/XClass/Controller/FormFrontendController.php
@@ -15,6 +15,7 @@ use FriendsOfTYPO3\Headless\Form\CustomOptionsInterface;
 use FriendsOfTYPO3\Headless\Form\Decorator\DefinitionDecoratorInterface;
 use FriendsOfTYPO3\Headless\Form\Decorator\FormDefinitionDecorator;
 use FriendsOfTYPO3\Headless\Form\Translator;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\XClass\FormRuntime;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
@@ -23,7 +24,6 @@ use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
 use TYPO3\CMS\Form\Domain\Factory\ArrayFormFactory;
 use TYPO3\CMS\Form\Domain\Model\FormDefinition;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 use function array_merge;
 use function array_pop;
@@ -62,11 +62,9 @@ class FormFrontendController extends \TYPO3\CMS\Form\Controller\FormFrontendCont
      */
     public function renderAction(): ResponseInterface
     {
-        // check if headless not loaded & call original method in case of fluid configuration
-        $typoScriptSetup = $GLOBALS['TSFE'] instanceof TypoScriptFrontendController ? $GLOBALS['TSFE']->tmpl->setup : [];
-        if (!isset($typoScriptSetup['plugin.']['tx_headless.']['staticTemplate'])
-            || (bool)$typoScriptSetup['plugin.']['tx_headless.']['staticTemplate'] === false
-        ) {
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class);
+
+        if (!$headlessMode->withRequest($GLOBALS['TYPO3_REQUEST'])->isEnabled()) {
             return parent::renderAction();
         }
 

--- a/Classes/XClass/Controller/LoginController.php
+++ b/Classes/XClass/Controller/LoginController.php
@@ -11,9 +11,10 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\XClass\Controller;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\FrontendLogin\Event\BeforeRedirectEvent;
 use TYPO3\CMS\FrontendLogin\Event\LoginConfirmedEvent;
 use TYPO3\CMS\FrontendLogin\Event\LoginErrorOccurredEvent;
@@ -120,8 +121,6 @@ class LoginController extends \TYPO3\CMS\FrontendLogin\Controller\LoginControlle
 
     private function isHeadlessEnabled(): bool
     {
-        $typoScriptSetup = $GLOBALS['TSFE'] instanceof TypoScriptFrontendController ? $GLOBALS['TSFE']->tmpl->setup : [];
-
-        return (bool)($typoScriptSetup['plugin.']['tx_headless.']['staticTemplate'] ?? false);
+        return GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST'])->isEnabled();
     }
 }

--- a/Classes/XClass/Controller/PreviewController.php
+++ b/Classes/XClass/Controller/PreviewController.php
@@ -25,11 +25,6 @@ class PreviewController extends \TYPO3\CMS\Workspaces\Controller\PreviewControll
     protected function generateUrl(Site $site, int $pageUid, array $parameters): string
     {
         $url = (string)$site->getRouter()->generateUri($pageUid, $parameters);
-
-        if ($site->getConfiguration()['headless'] ?? false) {
-            return GeneralUtility::makeInstance(UrlUtility::class)->getFrontendUrlForPage($url, $pageUid);
-        }
-
-        return $url;
+        return GeneralUtility::makeInstance(UrlUtility::class)->getFrontendUrlForPage($url, $pageUid);
     }
 }

--- a/Classes/XClass/ImageService.php
+++ b/Classes/XClass/ImageService.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\XClass;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\ApplicationType;
@@ -29,8 +30,12 @@ class ImageService extends \TYPO3\CMS\Extbase\Service\ImageService
      */
     protected function getImageFromSourceString(string $src, bool $treatIdAsReference): ?FileInterface
     {
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST']);
+
         if (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
-            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()) {
+            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()
+            && $headlessMode->isEnabled()
+        ) {
             $urlUtility = GeneralUtility::makeInstance(UrlUtility::class);
             $baseUriForProxy = $urlUtility->getProxyUrl();
 

--- a/Classes/XClass/Preview/PreviewUriBuilder.php
+++ b/Classes/XClass/Preview/PreviewUriBuilder.php
@@ -46,18 +46,9 @@ class PreviewUriBuilder extends \TYPO3\CMS\Workspaces\Preview\PreviewUriBuilder
                 $language = $site->getDefaultLanguage();
             }
 
-            return $this->prepareHeadlessUrl((string)$site->getRouter()->generateUri($uid, ['ADMCMD_prev' => $previewKeyword, '_language' => $language], ''), $uid, $site->getConfiguration()['headless'] ?? false);
+            return GeneralUtility::makeInstance(UrlUtility::class)->getFrontendUrlForPage((string)$site->getRouter()->generateUri($uid, ['ADMCMD_prev' => $previewKeyword, '_language' => $language], ''), $uid);
         } catch (SiteNotFoundException | InvalidRouteArgumentsException $e) {
             throw new UnableToLinkToPageException('The page ' . $uid . ' had no proper connection to a site, no link could be built.', 1559794916);
         }
-    }
-
-    protected function prepareHeadlessUrl(string $url, int $pageUid, bool $headlessMode): string
-    {
-        if ($headlessMode) {
-            return GeneralUtility::makeInstance(UrlUtility::class)->getFrontendUrlForPage($url, $pageUid);
-        }
-
-        return $url;
     }
 }

--- a/Classes/XClass/ResourceLocalDriver.php
+++ b/Classes/XClass/ResourceLocalDriver.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\XClass;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\ApplicationType;
@@ -25,8 +26,11 @@ class ResourceLocalDriver extends LocalDriver
 {
     protected function determineBaseUrl(): void
     {
-        if (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
-            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend()) {
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST']);
+
+        if ((($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
+            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend()) ||
+            !$headlessMode->isEnabled()) {
             parent::determineBaseUrl();
 
             return;

--- a/Classes/XClass/TemplateView.php
+++ b/Classes/XClass/TemplateView.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\XClass;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 
@@ -24,7 +26,9 @@ class TemplateView extends \TYPO3\CMS\Fluid\View\TemplateView
 {
     public function render($actionName = null)
     {
-        if (!ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()) {
+        $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST']);
+
+        if (!ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend() || !$headlessMode->isEnabled()) {
             return parent::render($actionName);
         }
 

--- a/Classes/XClass/Typolink/PageLinkBuilder.php
+++ b/Classes/XClass/Typolink/PageLinkBuilder.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\XClass\Typolink;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Psr\Http\Message\UriInterface;
 use TYPO3\CMS\Core\Http\Uri;
@@ -79,12 +80,16 @@ class PageLinkBuilder extends \TYPO3\CMS\Frontend\Typolink\PageLinkBuilder
             $uri = (new Uri())->withFragment($fragment);
         } else {
             try {
-                $urlUtility = GeneralUtility::makeInstance(UrlUtility::class)->withSite($siteOfTargetPage);
-                $frontendBaseUrl = $urlUtility->getFrontendUrl();
+                $headlessMode = GeneralUtility::makeInstance(HeadlessMode::class)->withRequest($GLOBALS['TYPO3_REQUEST']);
 
-                if ($frontendBaseUrl !== '') {
-                    $parsedFrontendBase = parse_url($frontendBaseUrl);
-                    $queryParameters['_frontendHost'] = $parsedFrontendBase['host'] ?? '';
+                if ($headlessMode->isEnabled()) {
+                    $urlUtility = GeneralUtility::makeInstance(UrlUtility::class)->withSite($siteOfTargetPage);
+                    $frontendBaseUrl = $urlUtility->getFrontendUrl();
+
+                    if ($frontendBaseUrl !== '') {
+                        $parsedFrontendBase = parse_url($frontendBaseUrl);
+                        $queryParameters['_frontendHost'] = $parsedFrontendBase['host'] ?? '';
+                    }
                 }
 
                 $uri = $siteOfTargetPage->getRouter()->generateUri(

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -8,6 +8,7 @@
  */
 
 use FriendsOfTYPO3\Headless\Middleware\ElementBodyResponseMiddleware;
+use FriendsOfTYPO3\Headless\Middleware\HeadlessModeSetter;
 use FriendsOfTYPO3\Headless\Middleware\RedirectHandler;
 use FriendsOfTYPO3\Headless\Middleware\ShortcutAndMountPointRedirect;
 use FriendsOfTYPO3\Headless\Middleware\SiteBaseRedirectResolver;
@@ -25,6 +26,12 @@ return (static function (): array {
                     'typo3/cms-frontend/content-length-headers',
                 ],
                 'target' => UserIntMiddleware::class
+            ],
+            'headless/mode-setter' => [
+                'before' => [
+                    'typo3/cms-frontend/base-redirect-resolver',
+                ],
+                'target' => HeadlessModeSetter::class
             ],
         ],
     ];

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -8,6 +8,7 @@
  */
 
 declare(strict_types=1);
+
 use FriendsOfTYPO3\Headless\Seo\XmlSitemap\XmlSitemapRenderer;
 use FriendsOfTYPO3\Headless\Utility\HeadlessFrontendUrlInterface;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;

--- a/Configuration/SiteConfiguration/Overrides/site.php
+++ b/Configuration/SiteConfiguration/Overrides/site.php
@@ -7,74 +7,88 @@
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 $features = GeneralUtility::makeInstance(Features::class);
 
-if ($features->isFeatureEnabled('headless.frontendUrls')) {
-    $tempColumns = [
-        'frontendBase' => [
-            'label' => 'Frontend Entry Point',
-            'description' => 'Main URL to call the frontend in default language.',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
-                'placeholder' => 'http://www.domain.local',
+$tempColumns = [
+    'frontendBase' => [
+        'label' => 'Frontend Entry Point',
+        'description' => 'Main URL to call the frontend in default language.',
+        'config' => [
+            'type' => 'input',
+            'eval' => 'trim',
+            'placeholder' => 'http://www.domain.local',
+        ],
+    ],
+    'headless' => [
+        'label' => 'Headless mode',
+        'description' => 'How site should behave in headless context',
+        'config' => [
+            'type' => 'select',
+            'renderType' => 'selectSingle',
+            'default' => HeadlessMode::NONE,
+            'items' => [
+                ['LLL:EXT:headless/Resources/Private/Language/locallang_be.xlf:site.headless.none', HeadlessMode::NONE],
+                ['LLL:EXT:headless/Resources/Private/Language/locallang_be.xlf:site.headless.full', HeadlessMode::FULL],
+                ['LLL:EXT:headless/Resources/Private/Language/locallang_be.xlf:site.headless.mixed', HeadlessMode::MIXED],
             ],
-        ]
+        ],
+    ]
+];
+
+$replaceShowItem = 'base, frontendBase, headless,';
+
+if ($features->isFeatureEnabled('headless.storageProxy')) {
+    $tempColumns['frontendApiProxy'] = [
+        'label' => 'Frontend API proxy url',
+        'description' => 'Main URL to for proxy API',
+        'config' => [
+            'type' => 'input',
+            'eval' => 'trim',
+            'placeholder' => 'http://www.domain.local/api',
+        ],
     ];
 
-    $replaceShowItem = 'base, frontendBase, ';
+    $tempColumns['frontendFileApi'] = [
+        'label' => 'Frontend API proxy url for files',
+        'description' => 'Main URL to for proxy API files',
+        'config' => [
+            'type' => 'input',
+            'eval' => 'trim',
+            'placeholder' => 'http://www.domain.local/api/fileadmin',
+        ],
+    ];
 
-    if ($features->isFeatureEnabled('headless.storageProxy')) {
-        $tempColumns['frontendApiProxy'] = [
-            'label' => 'Frontend API proxy url',
-            'description' => 'Main URL to for proxy API',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
-                'placeholder' => 'http://www.domain.local/api',
-            ],
-        ];
-
-        $tempColumns['frontendFileApi'] = [
-            'label' => 'Frontend API proxy url for files',
-            'description' => 'Main URL to for proxy API files',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
-                'placeholder' => 'http://www.domain.local/api/fileadmin',
-            ],
-        ];
-
-        $replaceShowItem .= 'frontendApiProxy, frontendFileApi,';
-    }
-
-    if ($features->isFeatureEnabled('headless.cookieDomainPerSite')) {
-        $tempColumns['cookieDomain'] = [
-            'label' => 'Cookie Domain',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
-                'placeholder' => '.ddev.site',
-            ],
-        ];
-
-        $replaceShowItem .= 'cookieDomain,';
-    }
-
-    $GLOBALS['SiteConfiguration']['site']['columns']['base']['label'] = 'TYPO3 Entry Point';
-    $GLOBALS['SiteConfiguration']['site']['columns']['base']['description'] = 'Main URL to call the TYPO3 headless api in default language.';
-
-    $GLOBALS['SiteConfiguration']['site']['columns'] = array_merge(
-        $GLOBALS['SiteConfiguration']['site']['columns'],
-        $tempColumns
-    );
-
-    $GLOBALS['SiteConfiguration']['site']['palettes']['base']['showitem'] = str_replace(
-        'base,',
-        $replaceShowItem,
-        $GLOBALS['SiteConfiguration']['site']['palettes']['base']['showitem']
-    );
+    $replaceShowItem .= 'frontendApiProxy, frontendFileApi,';
 }
+
+if ($features->isFeatureEnabled('headless.cookieDomainPerSite')) {
+    $tempColumns['cookieDomain'] = [
+        'label' => 'Cookie Domain',
+        'config' => [
+            'type' => 'input',
+            'eval' => 'trim',
+            'placeholder' => '.ddev.site',
+        ],
+    ];
+
+    $replaceShowItem .= 'cookieDomain,';
+}
+
+$GLOBALS['SiteConfiguration']['site']['columns']['base']['label'] = 'TYPO3 Entry Point';
+$GLOBALS['SiteConfiguration']['site']['columns']['base']['description'] = 'Main URL to call the TYPO3 headless api in default language.';
+
+$GLOBALS['SiteConfiguration']['site']['columns'] = array_merge(
+    $GLOBALS['SiteConfiguration']['site']['columns'],
+    $tempColumns
+);
+
+$GLOBALS['SiteConfiguration']['site']['palettes']['base']['showitem'] = str_replace(
+    'base,',
+    $replaceShowItem,
+    $GLOBALS['SiteConfiguration']['site']['palettes']['base']['showitem']
+);

--- a/Configuration/SiteConfiguration/Overrides/site_base_variant.php
+++ b/Configuration/SiteConfiguration/Overrides/site_base_variant.php
@@ -12,67 +12,65 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 $features = GeneralUtility::makeInstance(Features::class);
 
-if ($features->isFeatureEnabled('headless.frontendUrls')) {
-    $tempColumns = [
-        'frontendBase' => [
-            'label' => 'Frontend Entry Point',
-            'description' => 'For example "https://front.staging.domain.tld" or "http://front.domain.local"',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
-                'placeholder' => 'http://www.domain.local',
-            ],
-        ]
+$tempColumns = [
+    'frontendBase' => [
+        'label' => 'Frontend Entry Point',
+        'description' => 'For example "https://front.staging.domain.tld" or "http://front.domain.local"',
+        'config' => [
+            'type' => 'input',
+            'eval' => 'trim',
+            'placeholder' => 'http://www.domain.local',
+        ],
+    ],
+];
+
+$replaceShowItem = 'base, frontendBase,';
+
+if ($features->isFeatureEnabled('headless.storageProxy')) {
+    $tempColumns['frontendApiProxy'] = [
+        'label' => 'Frontend API proxy url',
+        'description' => 'Main URL to for proxy API',
+        'config' => [
+            'type' => 'input',
+            'eval' => 'trim',
+            'placeholder' => 'http://front-domain.tld/api',
+        ],
     ];
 
-    $replaceShowItem = 'base, frontendBase, ';
+    $tempColumns['frontendFileApi'] = [
+        'label' => 'Frontend API proxy url for files',
+        'description' => 'Main URL to for proxy API files',
+        'config' => [
+            'type' => 'input',
+            'eval' => 'trim',
+            'placeholder' => 'http://front-domain.tld/api/fileadmin',
+        ],
+    ];
 
-    if ($features->isFeatureEnabled('headless.storageProxy')) {
-        $tempColumns['frontendApiProxy'] = [
-            'label' => 'Frontend API proxy url',
-            'description' => 'Main URL to for proxy API',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
-                'placeholder' => 'http://front-domain.tld/api',
-            ],
-        ];
-
-        $tempColumns['frontendFileApi'] = [
-            'label' => 'Frontend API proxy url for files',
-            'description' => 'Main URL to for proxy API files',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
-                'placeholder' => 'http://front-domain.tld/api/fileadmin',
-            ],
-        ];
-
-        $replaceShowItem .= 'frontendApiProxy, frontendFileApi,';
-    }
-
-    if ($features->isFeatureEnabled('headless.cookieDomainPerSite')) {
-        $tempColumns['cookieDomain'] = [
-            'label' => 'Cookie Domain',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
-                'placeholder' => '.ddev.site',
-            ],
-        ];
-
-        $replaceShowItem .= 'cookieDomain,';
-    }
-
-    $GLOBALS['SiteConfiguration']['site_base_variant']['columns'] = array_merge(
-        $GLOBALS['SiteConfiguration']['site_base_variant']['columns'],
-        $tempColumns
-    );
-    $GLOBALS['SiteConfiguration']['site_base_variant']['columns']['base']['label'] = 'TYPO3 Entry Point';
-
-    $GLOBALS['SiteConfiguration']['site_base_variant']['types']['1']['showitem'] = str_replace(
-        'base,',
-        $replaceShowItem,
-        $GLOBALS['SiteConfiguration']['site_base_variant']['types']['1']['showitem']
-    );
+    $replaceShowItem .= 'frontendApiProxy, frontendFileApi,';
 }
+
+if ($features->isFeatureEnabled('headless.cookieDomainPerSite')) {
+    $tempColumns['cookieDomain'] = [
+        'label' => 'Cookie Domain',
+        'config' => [
+            'type' => 'input',
+            'eval' => 'trim',
+            'placeholder' => '.ddev.site',
+        ],
+    ];
+
+    $replaceShowItem .= 'cookieDomain,';
+}
+
+$GLOBALS['SiteConfiguration']['site_base_variant']['columns'] = array_merge(
+    $GLOBALS['SiteConfiguration']['site_base_variant']['columns'],
+    $tempColumns
+);
+$GLOBALS['SiteConfiguration']['site_base_variant']['columns']['base']['label'] = 'TYPO3 Entry Point';
+
+$GLOBALS['SiteConfiguration']['site_base_variant']['types']['1']['showitem'] = str_replace(
+    'base,',
+    $replaceShowItem,
+    $GLOBALS['SiteConfiguration']['site_base_variant']['types']['1']['showitem']
+);

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -21,6 +21,14 @@ call_user_func(static function () {
         'Headless'
     );
     /**
+     * Mixed-Mode TypoScript for Headless
+     */
+    ExtensionManagementUtility::addStaticFile(
+        'headless',
+        'Configuration/TypoScript/Mixed',
+        'Headless - Mixed mode JSON response'
+    );
+    /**
      * 2.x JSON response
      */
     ExtensionManagementUtility::addStaticFile(

--- a/Configuration/TypoScript/Configuration/FeLogin.typoscript
+++ b/Configuration/TypoScript/Configuration/FeLogin.typoscript
@@ -10,10 +10,3 @@ initialData.10.fields.user.fields {
     logged = BOOL
     logged.value = 0
 }
-
-[frontend.user.isLoggedIn]
-    initialData.10.fields.user.fields {
-        logged = BOOL
-        logged.value = 1
-    }
-[global]

--- a/Configuration/TypoScript/Configuration/PageConfiguration.typoscript
+++ b/Configuration/TypoScript/Configuration/PageConfiguration.typoscript
@@ -1,5 +1,7 @@
+page >
 page = PAGE
 page {
+    dataProcessing >
     typeNum = 0
     config {
         no_cache = 0

--- a/Configuration/TypoScript/LoggedUser/FeLogin.typoscript
+++ b/Configuration/TypoScript/LoggedUser/FeLogin.typoscript
@@ -1,0 +1,6 @@
+[frontend.user.isLoggedIn]
+    initialData.10.fields.user.fields {
+        logged = BOOL
+        logged.value = 1
+    }
+[END]

--- a/Configuration/TypoScript/Mixed/setup.typoscript
+++ b/Configuration/TypoScript/Mixed/setup.typoscript
@@ -1,0 +1,21 @@
+plugin.tx_headless {
+    # Do not remove this!
+    # This will indicate, that the static typoscript for EXT:headless was loaded
+    staticTemplate = 1
+}
+
+[traverse(request.getHeaders(), 'accept')[0] == 'application/json']
+    ## Include page
+    @import "EXT:headless/Configuration/TypoScript/Page/*.typoscript"
+    ## Include content elements
+    @import "EXT:headless/Configuration/TypoScript/ContentElement/*.typoscript"
+    ## Include configuration
+    @import "EXT:headless/Configuration/TypoScript/Configuration/*.typoscript"
+[END]
+
+[traverse(request.getHeaders(), 'accept')[0] == 'application/json' && frontend.user.isLoggedIn]
+    initialData.10.fields.user.fields {
+        logged = BOOL
+        logged.value = 1
+    }
+[END]

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -10,3 +10,4 @@ plugin.tx_headless {
 @import "EXT:headless/Configuration/TypoScript/ContentElement/*.typoscript"
 ## Include configuration
 @import "EXT:headless/Configuration/TypoScript/Configuration/*.typoscript"
+@import "EXT:headless/Configuration/TypoScript/Configuration/LoggedUser/FeLogin.typoscript"

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -12,4 +12,4 @@ plugin.tx_headless {
 @import "EXT:headless/Configuration/TypoScript/ContentElement/*.typoscript"
 ## Include configuration
 @import "EXT:headless/Configuration/TypoScript/Configuration/*.typoscript"
-@import "EXT:headless/Configuration/TypoScript/Configuration/LoggedUser/FeLogin.typoscript"
+@import "EXT:headless/Configuration/TypoScript/LoggedUser/FeLogin.typoscript"

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2">
+    <file source-language="en" datatype="plaintext" original="messages" date="2021-05-31T00:03:22Z" product-name="headless">
+        <header/>
+        <body>
+            <trans-unit approved="yes" id="mode">
+                <source>Headless mode</source>
+            </trans-unit>
+            <trans-unit approved="yes" id="site.headless.none">
+                <source>Headless disabled</source>
+            </trans-unit>
+            <trans-unit approved="yes" id="site.headless.full">
+                <source>Full headless mode</source>
+            </trans-unit>
+            <trans-unit approved="yes" id="site.headless.mixed">
+                <source>Mixed headless/fluid mode</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Tests/Unit/DataProcessing/RootSiteProcessing/DomainSchemaTest.php
+++ b/Tests/Unit/DataProcessing/RootSiteProcessing/DomainSchemaTest.php
@@ -13,6 +13,8 @@ namespace FriendsOfTYPO3\Headless\Test\Unit\DataProcessing\RootSiteProcessing;
 
 use FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\DomainSchema;
 use FriendsOfTYPO3\Headless\DataProcessing\RootSiteProcessing\SiteProvider;
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -139,8 +141,9 @@ class DomainSchemaTest extends UnitTestCase
 
         $siteFinder->getSiteByPageId(Argument::is(1))->willReturn($site);
         $dummyRequest = (new ServerRequest())->withAttribute('site', $site);
+        $dummyRequest = $dummyRequest->withAttribute('headless', new Headless());
 
-        return new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), $dummyRequest);
+        return new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), $dummyRequest, (new HeadlessMode())->withRequest($dummyRequest));
     }
 
     protected function getSiteWithBase(UriInterface $uri, $withLanguage = null)

--- a/Tests/Unit/Event/Listener/RedirectUrlAdditionalParamsListenerTest.php
+++ b/Tests/Unit/Event/Listener/RedirectUrlAdditionalParamsListenerTest.php
@@ -13,6 +13,8 @@ namespace FriendsOfTYPO3\Headless\Test\Unit\Event\Listener;
 
 use FriendsOfTYPO3\Headless\Event\Listener\RedirectUrlAdditionalParamsListener;
 use FriendsOfTYPO3\Headless\Event\RedirectUrlEvent;
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use FriendsOfTYPO3\Headless\XClass\Routing\PageRouter;
 use Prophecy\Argument;
@@ -244,6 +246,6 @@ class RedirectUrlAdditionalParamsListenerTest extends UnitTestCase
 
         $siteFinder->getSiteByPageId(Argument::is(1))->willReturn($site);
 
-        return new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        return new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, (new HeadlessMode())->withRequest((new ServerRequest())->withAttribute('headless', new Headless())));
     }
 }

--- a/Tests/Unit/Middleware/ElementBodyResponseMiddlewareTest.php
+++ b/Tests/Unit/Middleware/ElementBodyResponseMiddlewareTest.php
@@ -13,6 +13,8 @@ namespace FriendsOfTYPO3\Headless\Test\Unit\Middleware;
 
 use FriendsOfTYPO3\Headless\Json\JsonEncoder;
 use FriendsOfTYPO3\Headless\Middleware\ElementBodyResponseMiddleware;
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Prophecy\PhpUnit\ProphecyTrait;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -29,7 +31,7 @@ class ElementBodyResponseMiddlewareTest extends UnitTestCase
      */
     public function processTest()
     {
-        $middleware = new ElementBodyResponseMiddleware(new JsonEncoder());
+        $middleware = new ElementBodyResponseMiddleware(new JsonEncoder(), new HeadlessMode());
 
         $responseArray = ['content' => ['colPos1' => [['id' => 1]]]];
         $result = json_encode($responseArray['content']['colPos1'][0]);
@@ -120,7 +122,7 @@ class ElementBodyResponseMiddlewareTest extends UnitTestCase
             )
         );
 
-        $middleware = new ElementBodyResponseMiddleware(new JsonEncoder());
+        $middleware = new ElementBodyResponseMiddleware(new JsonEncoder(), new HeadlessMode());
 
         $responseArray = ['content' => ['colPos2' => null, 'colPos1' => [['id' => 1]]]];
         $result = json_encode($responseArray['content']['colPos1'][0]);
@@ -176,6 +178,8 @@ class ElementBodyResponseMiddlewareTest extends UnitTestCase
             $request = $request->withMethod($withMethod);
         }
 
+        $request = $request->withAttribute('headless', new Headless());
+
         if ($withSite) {
             $site = $this->prophesize(Site::class);
             $site->getConfiguration()->willReturn([
@@ -183,6 +187,7 @@ class ElementBodyResponseMiddlewareTest extends UnitTestCase
             ]);
 
             $request = $request->withAttribute('site', $site->reveal());
+            $request = $request->withAttribute('headless', new Headless($headless ? HeadlessMode::FULL : HeadlessMode::NONE));
         }
 
         return $request;

--- a/Tests/Unit/Middleware/HeadlessModeSetterTest.php
+++ b/Tests/Unit/Middleware/HeadlessModeSetterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Tests\Unit\Middleware;
+
+use FriendsOfTYPO3\Headless\Middleware\HeadlessModeSetter;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Frontend\Http\RequestHandler;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class HeadlessModeSetterTest extends UnitTestCase
+{
+    public function test(): void
+    {
+        $middleware = new HeadlessModeSetter();
+        $request = new ServerRequest();
+        $request = $request->withAttribute('site', new Site('test', 1, ['headless' => true]));
+        $handler = $this->createMock(RequestHandler::class);
+        $handler->method('handle')->willReturn(new Response());
+
+        $middleware->process($request, $handler);
+
+        self::assertTrue($GLOBALS['TYPO3_REQUEST']->getAttribute('headless')->getMode() === HeadlessMode::FULL);
+    }
+    public function testNotSet(): void
+    {
+        $middleware = new HeadlessModeSetter();
+        $request = new ServerRequest();
+        $handler = $this->createMock(RequestHandler::class);
+        $handler->method('handle')->willReturn(new Response());
+
+        $middleware->process($request, $handler);
+
+        self::assertTrue($GLOBALS['TYPO3_REQUEST']->getAttribute('headless')->getMode() === HeadlessMode::NONE);
+    }
+}

--- a/Tests/Unit/Middleware/ShortcutAndMountPointRedirectTest.php
+++ b/Tests/Unit/Middleware/ShortcutAndMountPointRedirectTest.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Headless\Test\Unit\Middleware;
 
 use FriendsOfTYPO3\Headless\Middleware\ShortcutAndMountPointRedirect;
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
@@ -37,7 +39,10 @@ class ShortcutAndMountPointRedirectTest extends UnitTestCase
         $genericHtml = '<body>test</body>';
         $linkRedirect = 'https://test.domain2.tld';
         $genericResponse = new HtmlResponse($genericHtml);
-        $middleware = new ShortcutAndMountPointRedirect();
+        $middleware = new ShortcutAndMountPointRedirect((new HeadlessMode())->withRequest((new ServerRequest())->withAttribute(
+            'headless',
+            ['mode' => HeadlessMode::FULL]
+        )));
 
         $correctRedirect = [
             'redirectUrl' => $linkRedirect,
@@ -65,7 +70,10 @@ class ShortcutAndMountPointRedirectTest extends UnitTestCase
 
         self::assertEquals($genericHtml, $initialDataResponse->getBody()->__toString());
 
-        $middleware = new ShortcutAndMountPointRedirect();
+        $middleware = new ShortcutAndMountPointRedirect((new HeadlessMode())->withRequest((new ServerRequest())->withAttribute(
+            'headless',
+            ['mode' => HeadlessMode::FULL]
+        )));
         $shortcutJsonDecoded = [
             'redirectUrl' => '/shortcut-target',
             'statusCode' => 307
@@ -84,7 +92,7 @@ class ShortcutAndMountPointRedirectTest extends UnitTestCase
         );
         self::assertEquals($shortcutJsonDecoded, json_decode($middlewareResponse->getBody()->__toString(), true));
 
-        $middleware = new ShortcutAndMountPointRedirect();
+        $middleware = new ShortcutAndMountPointRedirect((new HeadlessMode()));
 
         $testRedirectResponse = new RedirectResponse('https://test.domain.tld/shortcut-target', 307);
 
@@ -107,7 +115,7 @@ class ShortcutAndMountPointRedirectTest extends UnitTestCase
         );
         self::assertEquals($testRedirectResponse->getStatusCode(), $middlewareResponse->getStatusCode());
 
-        $middleware = new ShortcutAndMountPointRedirect();
+        $middleware = new ShortcutAndMountPointRedirect(new HeadlessMode());
 
         $linkRedirectResponse = $middleware->process(
             $this->getTestRequest(
@@ -125,7 +133,10 @@ class ShortcutAndMountPointRedirectTest extends UnitTestCase
         self::assertEquals($linkRedirect, $linkRedirectResponse->getHeader('location')[0]);
         self::assertEquals(303, $linkRedirectResponse->getStatusCode());
 
-        $middleware = new ShortcutAndMountPointRedirect();
+        $middleware = new ShortcutAndMountPointRedirect((new HeadlessMode())->withRequest((new ServerRequest())->withAttribute(
+            'headless',
+            ['mode' => HeadlessMode::FULL]
+        )));
         $GLOBALS['TSFE'] = $this->getTsfeProphecy(
             '0',
             ['id' => 1, 'doktype' => PageRepository::DOKTYPE_DEFAULT, 'url' => $linkRedirect]
@@ -166,7 +177,10 @@ class ShortcutAndMountPointRedirectTest extends UnitTestCase
         $genericHtml = '<body>test</body>';
         $genericResponse = new HtmlResponse($genericHtml);
 
-        $middleware = new ShortcutAndMountPointRedirect();
+        $middleware = new ShortcutAndMountPointRedirect((new HeadlessMode())->withRequest((new ServerRequest())->withAttribute(
+            'headless',
+            ['mode' => HeadlessMode::FULL]
+        )));
 
         $linkRedirectResponse = $middleware->process(
             $this->getTestRequest(
@@ -217,8 +231,11 @@ class ShortcutAndMountPointRedirectTest extends UnitTestCase
             $request = $request->withAttribute('frontend.controller', $withTsfe);
         }
 
+        $request = $request->withAttribute('headless', new Headless());
+
         if ($withEnabledHeadless) {
-            return $request->withAttribute('site', new Site('test_site', 1, ['headless' => true]));
+            $request = $request->withAttribute('site', new Site('test_site', 1, ['headless' => true]));
+            return $request->withAttribute('headless', new Headless(HeadlessMode::FULL));
         }
 
         return $request;

--- a/Tests/Unit/Utility/HeadlessModeTest.php
+++ b/Tests/Unit/Utility/HeadlessModeTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace FriendsOfTYPO3\Headless\Tests\Unit\Utility;
+
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Http\ServerRequest;
+
+class HeadlessModeTest extends TestCase
+{
+    public function testMixedModeWithoutHeader(): void
+    {
+        $mode = new HeadlessMode();
+
+        $request =  new ServerRequest();
+        $request = $request->withAttribute('headless', new Headless(HeadlessMode::MIXED));
+
+        $mode = $mode->withRequest($request);
+
+        self::assertFalse($mode->isEnabled());
+    }
+
+    public function testMixedModeWithHeader(): void
+    {
+        $mode = new HeadlessMode();
+
+        $request =  new ServerRequest();
+        $request = $request->withHeader('Accept', 'application/json');
+        $request = $request->withAttribute('headless', new Headless(HeadlessMode::MIXED));
+
+        $mode = $mode->withRequest($request);
+
+        self::assertTrue($mode->isEnabled());
+    }
+
+    public function testDisabled(): void
+    {
+        $mode = new HeadlessMode();
+
+        $request =  new ServerRequest();
+        $request = $request->withHeader('Accept', 'application/json');
+        $request = $request->withAttribute('headless', new Headless(HeadlessMode::NONE));
+
+        $mode = $mode->withRequest($request);
+
+        self::assertFalse($mode->isEnabled());
+    }
+
+    public function testNotSet(): void
+    {
+        $mode = new HeadlessMode();
+
+        $request =  new ServerRequest();
+        $request = $request->withHeader('Accept', 'application/json');
+
+        $mode = $mode->withRequest($request);
+
+        self::assertFalse($mode->isEnabled());
+        // without passed request
+        self::assertFalse((new HeadlessMode())->isEnabled());
+    }
+
+    public function testFullMode(): void
+    {
+        $mode = new HeadlessMode();
+
+        $request = new ServerRequest();
+        $request = $request->withAttribute('headless', new Headless(HeadlessMode::FULL));
+
+        $mode = $mode->withRequest($request);
+
+        self::assertTrue($mode->isEnabled());
+    }
+}

--- a/Tests/Unit/Utility/UrlUtilityTest.php
+++ b/Tests/Unit/Utility/UrlUtilityTest.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\Test\Unit\Utility;
 
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -30,6 +32,8 @@ class UrlUtilityTest extends UnitTestCase
 
     public function testFrontendUrls(): void
     {
+        $headlessMode = $this->createHeadlessMode();
+
         $site = $this->prophesize(Site::class);
         $site->getConfiguration()->shouldBeCalled(3)->willReturn([
             'base' => 'https://www.typo3.org',
@@ -68,7 +72,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame('https://test-frontend.tld', $urlUtility->getFrontendUrl());
@@ -82,7 +86,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame('https://test-frontend2.tld', $urlUtility->getFrontendUrl());
@@ -97,7 +101,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame('https://test-frontend3.tld', $urlUtility->getFrontendUrl());
@@ -134,7 +138,9 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::containingString('Development'))->willReturn(true);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $headlessMode = $this->createHeadlessMode();
+
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame('https://test-frontend.tld', $urlUtility->getFrontendUrl());
@@ -146,7 +152,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::containingString('Development'))->willReturn(false);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         self::assertSame('https://www.typo3.org', $urlUtility->getFrontendUrl());
@@ -157,6 +163,8 @@ class UrlUtilityTest extends UnitTestCase
 
     public function testOptimizedUrlsForFrontendApp(): void
     {
+        $headlessMode = $this->createHeadlessMode();
+
         $site = $this->prophesize(Site::class);
         $site->getConfiguration()->shouldBeCalled(2)->willReturn([
             'base' => 'https://www.typo3.org',
@@ -185,7 +193,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         // same page, so we make it relative
@@ -214,7 +222,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         // same page, so we make it relative
@@ -251,6 +259,8 @@ class UrlUtilityTest extends UnitTestCase
 
     public function testLanguageResolver(): void
     {
+        $headlessMode = $this->createHeadlessMode();
+
         $site = $this->prophesize(Site::class);
         $site->getConfiguration()->shouldBeCalled(2)->willReturn([
             'base' => 'https://www.typo3.org',
@@ -279,7 +289,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
         $urlUtility = $urlUtility->withLanguage(new SiteLanguage(0, 'en', new Uri('/'), [
             'title' =>  'English',
@@ -353,7 +363,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
         $urlUtility = $urlUtility->withLanguage(new SiteLanguage(0, 'en', new Uri('/'), [
             'title' =>  'English',
@@ -391,6 +401,7 @@ class UrlUtilityTest extends UnitTestCase
     public function testFrontendUrlForPage(): void
     {
         $site = $this->prophesize(Site::class);
+        $site->getBase()->willReturn(new Uri('https://test-backend-api.tld'));
         $site->getConfiguration()->shouldBeCalled(2)->willReturn([
             'base' => 'https://www.typo3.org',
             'languages' => [],
@@ -415,7 +426,8 @@ class UrlUtilityTest extends UnitTestCase
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalledOnce()->willReturn($site->reveal());
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $headlessMode = $this->createHeadlessMode(HeadlessMode::NONE);
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         // flag is not existing/disabled
@@ -424,8 +436,10 @@ class UrlUtilityTest extends UnitTestCase
             $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld/test-page', 1)
         );
 
-        // flag is enabled
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['headless.frontendUrls'] = true;
+        $headlessMode = $this->createHeadlessMode(HeadlessMode::FULL);
+
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
+        $urlUtility = $urlUtility->withSite($site->reveal());
         self::assertSame(
             'https://test-frontend.tld/test-page',
             $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld/test-page', 1)
@@ -457,11 +471,11 @@ class UrlUtilityTest extends UnitTestCase
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalledOnce()->willReturn($site->reveal());
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $headlessMode = $this->createHeadlessMode();
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         // flag is enabled
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['headless.frontendUrls'] = true;
         self::assertSame(
             'https://front.api.tld/test-page',
             $urlUtility->getFrontendUrlForPage('https://front.api.tld/test-page', 1)
@@ -487,7 +501,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $uri = new Uri('https://test-backend-api.tld');
 
-        $site->getBase()->shouldBeCalled(2)->willReturn($uri);
+        $site->getBase()->willReturn($uri);
 
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::any())->willReturn(true);
@@ -495,7 +509,8 @@ class UrlUtilityTest extends UnitTestCase
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalledOnce()->willReturn($site->reveal());
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $headlessMode = $this->createHeadlessMode(HeadlessMode::NONE);
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         // flag is not existing/disabled
@@ -505,7 +520,9 @@ class UrlUtilityTest extends UnitTestCase
         );
 
         // flag is enabled
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['headless.frontendUrls'] = true;
+        $headlessMode = $this->createHeadlessMode();
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
+        $urlUtility = $urlUtility->withSite($site->reveal());
         self::assertSame(
             'https://test-frontend.tld:3000/test-page',
             $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld/test-page', 1)
@@ -514,6 +531,7 @@ class UrlUtilityTest extends UnitTestCase
 
     public function testFrontendUrlForPageWithPortsOnBothSides(): void
     {
+        $headlessMode = $this->createHeadlessMode(HeadlessMode::NONE);
         $site = $this->prophesize(Site::class);
         $site->getConfiguration()->shouldBeCalled(2)->willReturn([
             'base' => 'https://www.typo3.org',
@@ -531,7 +549,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $uri = new Uri('https://test-backend-api.tld:8000');
 
-        $site->getBase()->shouldBeCalled(2)->willReturn($uri);
+        $site->getBase()->willReturn($uri);
 
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::any())->willReturn(true);
@@ -539,7 +557,7 @@ class UrlUtilityTest extends UnitTestCase
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalledOnce()->willReturn($site->reveal());
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());
 
         // flag is not existing/disabled
@@ -549,7 +567,9 @@ class UrlUtilityTest extends UnitTestCase
         );
 
         // flag is enabled
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['headless.frontendUrls'] = true;
+        $headlessMode = $this->createHeadlessMode();
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
+        $urlUtility = $urlUtility->withSite($site->reveal());
         self::assertSame(
             'https://test-frontend.tld:3000/test-page',
             $urlUtility->getFrontendUrlForPage('https://test-backend-api.tld:8000/test-page', 1)
@@ -558,9 +578,13 @@ class UrlUtilityTest extends UnitTestCase
 
     public function testEdgeCases()
     {
+        $headlessMode = $this->createHeadlessMode();
+
         $site = $this->createMockSite('https://test-backend-api.tld:8000');
         $request = $this->prophesize(ServerRequest::class);
         $request->getAttribute(Argument::is('site'))->willReturn($site);
+        $request->getAttribute(Argument::is('headless'))->willReturn(new Headless(HeadlessMode::FULL));
+        $request->getHeader(Argument::is('Accept'))->willReturn([]);
         $request->getAttribute(Argument::is('language'))->willReturn(null);
 
         $resolver = $this->prophesize(Resolver::class);
@@ -568,7 +592,7 @@ class UrlUtilityTest extends UnitTestCase
 
         $siteFinder = $this->prophesize(SiteFinder::class);
         $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalledOnce()->willReturn($site);
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), $request->reveal(), null, $headlessMode);
 
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['headless.frontendUrls'] = true;
         self::assertSame(
@@ -588,7 +612,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->createPartialMock(Resolver::class, ['evaluate']);
         $resolver->method('evaluate')->willThrowException(new SyntaxError('test'));
 
-        $urlUtility = new UrlUtility(null, $resolver, $siteFinder, $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver, $siteFinder, $request->reveal(), $headlessMode);
         self::assertSame('', $urlUtility->getFrontendUrl());
 
         $urlUtility = $urlUtility->withSite($this->createMockSite('https://test-frontend.tld', '', []));
@@ -622,7 +646,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::any())->willReturn(true);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal(), $headlessMode);
         self::assertSame('https://test-frontend-from-lang.tld', $urlUtility->getFrontendUrl());
 
         $request = $this->prophesize(ServerRequest::class);
@@ -644,7 +668,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::any())->willReturn(true);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal(), $headlessMode);
         self::assertSame('', $urlUtility->getFrontendUrl());
 
         // configuration on language lvl without variants
@@ -670,7 +694,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::any())->willReturn(true);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal(), $headlessMode);
         self::assertSame('https://frontend-domain-from-lang.tld', $urlUtility->getFrontendUrl());
         self::assertSame('https://frontend-domain-from-lang.tld/headless', $urlUtility->getProxyUrl());
         self::assertSame('https://frontend-domain-from-lang.tld/headless/fileadmin', $urlUtility->getStorageProxyUrl());
@@ -708,7 +732,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver = $this->prophesize(Resolver::class);
         $resolver->evaluate(Argument::any())->willReturn(true);
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal());
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, $request->reveal(), $headlessMode);
         self::assertSame('https://test-frontend-from-when-develop-lang.tld', $urlUtility->getFrontendUrl());
         self::assertSame('https://test-frontend-from-when-develop-lang.tld/headless', $urlUtility->getProxyUrl());
         self::assertSame('https://test-frontend-from-when-develop-lang.tld/headless/fileadmin', $urlUtility->getStorageProxyUrl());
@@ -741,7 +765,7 @@ class UrlUtilityTest extends UnitTestCase
             ],
         ]));
 
-        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder);
+        $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder, null, $headlessMode);
         $urlUtilityWithRequest = $urlUtility->withRequest($manualRequest->reveal());
         self::assertSame('https://test-frontend-from-from-request-lang.tld', $urlUtilityWithRequest->getFrontendUrl());
         self::assertSame('https://test-frontend-from-from-request-lang.tld/headless', $urlUtilityWithRequest->getProxyUrl());
@@ -772,5 +796,15 @@ class UrlUtilityTest extends UnitTestCase
         $uri = new Uri($backendUrl);
         $site->getBase()->willReturn($uri);
         return $site->reveal();
+    }
+
+    private function createHeadlessMode(int $mode =  HeadlessMode::FULL): HeadlessMode
+    {
+        $headlessMode = new HeadlessMode();
+
+        $request =  new ServerRequest();
+        $request = $request->withAttribute('headless', new Headless($mode));
+
+        return $headlessMode->withRequest($request);
     }
 }

--- a/Tests/Unit/Utility/UrlUtilityTest.php
+++ b/Tests/Unit/Utility/UrlUtilityTest.php
@@ -424,7 +424,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver->evaluate(Argument::any())->willReturn(true);
 
         $siteFinder = $this->prophesize(SiteFinder::class);
-        $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalledOnce()->willReturn($site->reveal());
+        $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalled(2)->willReturn($site->reveal());
 
         $headlessMode = $this->createHeadlessMode(HeadlessMode::NONE);
         $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
@@ -507,7 +507,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver->evaluate(Argument::any())->willReturn(true);
 
         $siteFinder = $this->prophesize(SiteFinder::class);
-        $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalledOnce()->willReturn($site->reveal());
+        $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalled(2)->willReturn($site->reveal());
 
         $headlessMode = $this->createHeadlessMode(HeadlessMode::NONE);
         $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
@@ -555,7 +555,7 @@ class UrlUtilityTest extends UnitTestCase
         $resolver->evaluate(Argument::any())->willReturn(true);
 
         $siteFinder = $this->prophesize(SiteFinder::class);
-        $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalledOnce()->willReturn($site->reveal());
+        $siteFinder->getSiteByPageId(Argument::is(1))->shouldBeCalled(2)->willReturn($site->reveal());
 
         $urlUtility = new UrlUtility(null, $resolver->reveal(), $siteFinder->reveal(), null, $headlessMode);
         $urlUtility = $urlUtility->withSite($site->reveal());

--- a/Tests/Unit/XClass/Fixtures/Templates/Default/DefaultException.php
+++ b/Tests/Unit/XClass/Fixtures/Templates/Default/DefaultException.php
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+throw new RuntimeException('Example exception in template');

--- a/Tests/Unit/XClass/TemplateViewTest.php
+++ b/Tests/Unit/XClass/TemplateViewTest.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\Tests\Unit\XClass;
 
+use FriendsOfTYPO3\Headless\Utility\Headless;
+use FriendsOfTYPO3\Headless\Utility\HeadlessMode;
 use FriendsOfTYPO3\Headless\XClass\TemplateView;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
@@ -29,7 +31,8 @@ class TemplateViewTest extends UnitTestCase
     {
         $this->expectException(InvalidTemplateResourceException::class);
 
-        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())->withAttribute('applicationType', 1); // fe request
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())->withAttribute('applicationType', 1) // fe request
+            ->withAttribute('headless', new Headless());
 
         $context = new RenderingContext($this->createMock(ViewHelperResolver::class), $this->createMock(FluidCacheInterface::class), [], []);
 
@@ -50,7 +53,8 @@ class TemplateViewTest extends UnitTestCase
 
     public function testTemplateRender(): void
     {
-        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())->withAttribute('applicationType', 1); // fe request
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())->withAttribute('applicationType', 1) // fe request
+            ->withAttribute('headless', new Headless(HeadlessMode::FULL));
 
         $context = new RenderingContext($this->createMock(ViewHelperResolver::class), $this->createMock(FluidCacheInterface::class), [], []);
 
@@ -68,5 +72,79 @@ class TemplateViewTest extends UnitTestCase
         $view = new TemplateView($context);
 
         self::assertSame(json_encode(['testKey' => 'TestingJsonValue']), $view->render());
+    }
+
+    public function testTemplateFoundRender(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())->withAttribute('applicationType', 1) // fe request
+            ->withAttribute('headless', new Headless(HeadlessMode::FULL));
+
+        $context = new RenderingContext($this->createMock(ViewHelperResolver::class), $this->createMock(FluidCacheInterface::class), [], []);
+
+        $variableProvider = new StandardVariableProvider();
+        $variableProvider->add('settings', ['phpTemplate' => 1]);
+        $variableProvider->add('testValue', 'TestingJsonValue');
+
+        $context->setVariableProvider($variableProvider);
+
+        $templatePaths = $this->createMock(TemplatePaths::class);
+        $templatePaths->method('resolveTemplateFileForControllerAndActionAndFormat')->willReturn(null);
+
+        $context->setTemplatePaths($templatePaths);
+
+        $this->expectException(InvalidTemplateResourceException::class);
+
+        $view = new TemplateView($context);
+        $view->render();
+    }
+
+    public function testChangingAction(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())->withAttribute('applicationType', 1) // fe request
+            ->withAttribute('headless', new Headless(HeadlessMode::FULL));
+
+        $context = new RenderingContext($this->createMock(ViewHelperResolver::class), $this->createMock(FluidCacheInterface::class), [], []);
+
+        $variableProvider = new StandardVariableProvider();
+        $variableProvider->add('settings', ['phpTemplate' => 1]);
+        $variableProvider->add('testValue', 'TestingJsonValue');
+
+        $context->setVariableProvider($variableProvider);
+
+        $templatePaths = $this->createMock(TemplatePaths::class);
+        $templatePaths->method('resolveTemplateFileForControllerAndActionAndFormat')->willReturn(__DIR__ . '/Fixtures/Templates/Default/Default.php');
+
+        $context->setTemplatePaths($templatePaths);
+
+        self::assertSame('Default', $context->getControllerAction());
+
+        $view = new TemplateView($context);
+        $view->render('test');
+        self::assertSame('Test', $context->getControllerAction());
+    }
+
+    public function testExceptionInTemplate(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())->withAttribute('applicationType', 1) // fe request
+            ->withAttribute('headless', new Headless(HeadlessMode::FULL));
+
+        $context = new RenderingContext($this->createMock(ViewHelperResolver::class), $this->createMock(FluidCacheInterface::class), [], []);
+
+        $variableProvider = new StandardVariableProvider();
+        $variableProvider->add('settings', ['phpTemplate' => 1]);
+        $variableProvider->add('testValue', 'TestingJsonValue');
+
+        $context->setVariableProvider($variableProvider);
+
+        $templatePaths = $this->createMock(TemplatePaths::class);
+        $templatePaths->method('resolveTemplateFileForControllerAndActionAndFormat')->willReturn(__DIR__ . '/Fixtures/Templates/Default/DefaultException.php');
+
+        $context->setTemplatePaths($templatePaths);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Example exception in template');
+
+        $view = new TemplateView($context);
+        $view->render();
     }
 }


### PR DESCRIPTION
Patch introduces new way for checking if we are in headless mode, you can set not enabled, mixed mode (fluid & headless at the same time), or full headless mode.

Mixed mode depends on `Accept` header sent when requesting the site.

To configure headless mode, please use site configuration flag, for example: `
   'headless': 0|1|2
`
Legacy flag (true|false) is respected, but please migrate to int notation

Where:
 0 (old: false) = headless disabled
 1 (old: true) = headless fully enabled
 2 = headless in mixed mode

 In mixed mode also you need to load special "Headless - Mixed mode JSON response" typoscript in order to work properly, default one overrides fluid one.