### PR TITLE
[FEATURE] Add categories DataProcessor

### DIFF
--- a/Classes/DataProcessing/CategoriesProcessor.php
+++ b/Classes/DataProcessing/CategoriesProcessor.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\DataProcessing;
 
-
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;

--- a/Classes/DataProcessing/CategoriesProcessor.php
+++ b/Classes/DataProcessing/CategoriesProcessor.php
@@ -43,7 +43,6 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
  *
  * @codeCoverageIgnore
  **/
-
 class CategoriesProcessor implements DataProcessorInterface
 {
     /**

--- a/Classes/DataProcessing/CategoriesProcessor.php
+++ b/Classes/DataProcessing/CategoriesProcessor.php
@@ -40,6 +40,21 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
  *           }
  *       }
  *   }
+ *  Example usage (get categories by comma-separated-list of category ids from custom pid):
+ *
+ *    categories = JSON
+ *    categories {
+ *        dataProcessing {
+ *            10 = headless-categories
+ *            10 {
+ *                categoryIdList = 1,3,5
+ *                pidInList = leveluid:0
+ *                recursive = 250
+ *
+ *                as = categories
+ *            }
+ *        }
+ *    }
  *
  * @codeCoverageIgnore
  **/
@@ -66,7 +81,8 @@ class CategoriesProcessor implements DataProcessorInterface
         }
 
         $defaultQueryConfig = [
-            'pidInList' => 'root',
+            'pidInList' => (string)$cObj->stdWrapValue('pidInList', $processorConfiguration, 'root'),
+            'recursive' => (string)$cObj->stdWrapValue('recursive', $processorConfiguration, '0'),
             'selectFields' => '{#sys_category}.{#uid} AS id, {#sys_category}.{#title}',
         ];
         $queryConfig = [];

--- a/Classes/DataProcessing/CategoriesProcessor.php
+++ b/Classes/DataProcessing/CategoriesProcessor.php
@@ -34,7 +34,7 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
  *       dataProcessing {
  *           10 = headless-categories
  *           10 {
- *               categoryIdList = 1,3,5
+ *               uidInList = 1,3,5
  *
  *               as = categories
  *           }
@@ -47,7 +47,7 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
  *        dataProcessing {
  *            10 = headless-categories
  *            10 {
- *                categoryIdList = 1,3,5
+ *                uidInList = 1,3,5
  *                pidInList = leveluid:0
  *                recursive = 250
  *
@@ -87,10 +87,10 @@ class CategoriesProcessor implements DataProcessorInterface
         ];
         $queryConfig = [];
 
-        $categoryIdList = (string)$cObj->stdWrapValue('categoryIdList', $processorConfiguration, '');
-        if (empty($categoryIdList) === false) {
+        $uidInList = (string)$cObj->stdWrapValue('uidInList', $processorConfiguration, '');
+        if (empty($uidInList) === false) {
             $queryConfig = [
-                'where' => '{#sys_category.uid} IN (' . $categoryIdList . ')',
+                'uidInList' => $uidInList,
                 'languageField' => 0,
             ];
         }

--- a/Classes/DataProcessing/CategoriesProcessor.php
+++ b/Classes/DataProcessing/CategoriesProcessor.php
@@ -15,33 +15,34 @@ use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
 
-/*
+/**
  * Example usage (get categories by relation field):
-    categories = JSON
-    categories {
-        dataProcessing {
-            10 = headless-categories
-            10 {
-                relation.fieldName = categories
-
-                as = categories
-            }
-        }
-    }
+ *  categories = JSON
+ *  categories {
+ *      dataProcessing {
+ *          10 = headless-categories
+ *          10 {
+ *              relation.fieldName = categories
+ *              as = categories
+ *          }
+ *      }
+ *  }
  * Example usage (get categories by comma-separated-list of category ids):
-
-    categories = JSON
-    categories {
-        dataProcessing {
-            10 = headless-categories
-            10 {
-                categoryIdList = 1,3,5
-
-                as = categories
-            }
-        }
-    }
- */
+ *
+ *   categories = JSON
+ *   categories {
+ *       dataProcessing {
+ *           10 = headless-categories
+ *           10 {
+ *               categoryIdList = 1,3,5
+ *
+ *               as = categories
+ *           }
+ *       }
+ *   }
+ *
+ * @codeCoverageIgnore
+ **/
 
 class CategoriesProcessor implements DataProcessorInterface
 {

--- a/Classes/DataProcessing/CategoriesProcessor.php
+++ b/Classes/DataProcessing/CategoriesProcessor.php
@@ -67,7 +67,7 @@ class CategoriesProcessor implements DataProcessorInterface
 
         $defaultQueryConfig = [
             'pidInList' => 'root',
-            'selectFields' => 'uid AS id,title',
+            'selectFields' => '{#sys_category}.{#uid} AS id, {#sys_category}.{#title}',
         ];
         $queryConfig = [];
 
@@ -79,7 +79,6 @@ class CategoriesProcessor implements DataProcessorInterface
             ];
         }
 
-
         if (!empty($processorConfiguration['relation.'])) {
             $referenceConfiguration = $processorConfiguration['relation.'];
             $relationField = $cObj->stdWrapValue('fieldName', $referenceConfiguration ?? []);
@@ -88,8 +87,8 @@ class CategoriesProcessor implements DataProcessorInterface
 
                 if (!empty($relationTable)) {
                     $queryConfig = [
-                        'join' => 'sys_category_record_mm on sys_category_record_mm.uid_local = sys_category.uid',
-                        'where' => '({#sys_category_record_mm.tablenames} = \'' . $relationTable . '\' AND {#sys_category_record_mm.fieldname} = \'' . $relationField . '\' AND {#sys_category_record_mm.uid_foreign}=' . $cObj->data['uid'] . ')',
+                        'join' => '{#sys_category_record_mm} on {#sys_category_record_mm}.{#uid_local} = {#sys_category}.{#uid}',
+                        'where' => '({#sys_category_record_mm}.{#tablenames} = \'' . $relationTable . '\' AND {#sys_category_record_mm}.{#fieldname} = \'' . $relationField . '\' AND {#sys_category_record_mm}.{#uid_foreign}=' . $cObj->data['uid'] . ')',
                     ];
                 }
             }

--- a/Classes/DataProcessing/CategoriesProcessor.php
+++ b/Classes/DataProcessing/CategoriesProcessor.php
@@ -62,9 +62,7 @@ class CategoriesProcessor implements DataProcessorInterface
         array $contentObjectConfiguration,
         array $processorConfiguration,
         array $processedData
-    ): array
-    {
-
+    ): array {
         if (isset($processorConfiguration['if.']) && !$cObj->checkIf($processorConfiguration['if.'])) {
             return $processedData;
         }
@@ -75,20 +73,20 @@ class CategoriesProcessor implements DataProcessorInterface
 
         $defaultQueryConfig = [
             'pidInList' => 'root',
-            'selectFields' => 'uid AS id,title'
+            'selectFields' => 'uid AS id,title',
         ];
 
         if (empty($categoryIdList) === false) {
             $queryConfig = [
                 'where' => '{#sys_category.uid} IN (' . $categoryIdList . ')',
-                'languageField' => 0
+                'languageField' => 0,
             ];
         }
 
         if (empty($relationTable) === false && empty($relationUid) === false) {
             $queryConfig = [
                 'join' => 'sys_category_record_mm on sys_category_record_mm.uid_local = sys_category.uid',
-                'where' => '({#sys_category_record_mm.tablenames} = \'' . $relationTable . '\' AND {#sys_category_record_mm.uid_foreign}=' . $relationUid . ')'
+                'where' => '({#sys_category_record_mm.tablenames} = \'' . $relationTable . '\' AND {#sys_category_record_mm.uid_foreign}=' . $relationUid . ')',
             ];
         }
 

--- a/Classes/DataProcessing/CategoriesProcessor.php
+++ b/Classes/DataProcessing/CategoriesProcessor.php
@@ -88,7 +88,7 @@ class CategoriesProcessor implements DataProcessorInterface
         $queryConfig = [];
 
         $uidInList = (string)$cObj->stdWrapValue('uidInList', $processorConfiguration, '');
-        if (empty($uidInList) === false) {
+        if (!empty($uidInList)) {
             $queryConfig = [
                 'uidInList' => $uidInList,
                 'languageField' => 0,

--- a/Classes/DataProcessing/CategoriesProcessor.php
+++ b/Classes/DataProcessing/CategoriesProcessor.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\DataProcessing;
+
+
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
+
+/*
+ * Example usage (get categories by relation record):
+    categories = JSON
+    categories {
+        dataProcessing {
+            10 = headless-categories
+            10 {
+                relationTable = pages
+                relationUid.field = uid
+
+                as = categories
+            }
+        }
+    }
+ * Example usage (get categories by comma-separated-list of category ids):
+
+    categories = JSON
+    categories {
+        dataProcessing {
+            10 = headless-categories
+            10 {
+                categoryIdList = 1,3,5
+
+                as = categories
+            }
+        }
+    }
+ */
+
+class CategoriesProcessor implements DataProcessorInterface
+{
+    /**
+     * Fetches categories from the database
+     *
+     * @param ContentObjectRenderer $cObj The data of the content element or page
+     * @param array $contentObjectConfiguration The configuration of Content Object
+     * @param array $processorConfiguration The configuration of this processor
+     * @param array $processedData Key/value store of processed data (e.g. to be passed to a Fluid View)
+     *
+     * @return array the processed data as key/value store
+     */
+    public function process(
+        ContentObjectRenderer $cObj,
+        array $contentObjectConfiguration,
+        array $processorConfiguration,
+        array $processedData
+    ): array
+    {
+
+        if (isset($processorConfiguration['if.']) && !$cObj->checkIf($processorConfiguration['if.'])) {
+            return $processedData;
+        }
+
+        $relationTable = $cObj->stdWrapValue('relationTable', $processorConfiguration);
+        $relationUid = (int)$cObj->stdWrapValue('relationUid', $processorConfiguration);
+        $categoryIdList = (string)$cObj->stdWrapValue('categoryIdList', $processorConfiguration, '');
+
+        $defaultQueryConfig = [
+            'pidInList' => 'root',
+            'selectFields' => 'uid AS id,title'
+        ];
+
+        if (empty($categoryIdList) === false) {
+            $queryConfig = [
+                'where' => '{#sys_category.uid} IN (' . $categoryIdList . ')',
+                'languageField' => 0
+            ];
+        }
+
+        if (empty($relationTable) === false && empty($relationUid) === false) {
+            $queryConfig = [
+                'join' => 'sys_category_record_mm on sys_category_record_mm.uid_local = sys_category.uid',
+                'where' => '({#sys_category_record_mm.tablenames} = \'' . $relationTable . '\' AND {#sys_category_record_mm.uid_foreign}=' . $relationUid . ')'
+            ];
+        }
+
+        ArrayUtility::mergeRecursiveWithOverrule(
+            $queryConfig,
+            $defaultQueryConfig
+        );
+
+        $targetVariableName = $cObj->stdWrapValue('as', $processorConfiguration, 'categories');
+        $categories = $cObj->getRecords('sys_category', $queryConfig);
+
+        $processedRecordVariables = [];
+        foreach ($categories as $key => $category) {
+            $processedRecordVariables[$key] = ArrayUtility::filterRecursive($category, function ($key) {
+                return $key === 'id' || $key === 'title';
+            }, ARRAY_FILTER_USE_KEY);
+        }
+
+        $processedData[$targetVariableName] = $processedRecordVariables;
+
+        return $processedData;
+    }
+}

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -14,6 +14,7 @@ use FriendsOfTYPO3\Headless\ContentObject\FloatContentObject;
 use FriendsOfTYPO3\Headless\ContentObject\IntegerContentObject;
 use FriendsOfTYPO3\Headless\ContentObject\JsonContentContentObject;
 use FriendsOfTYPO3\Headless\ContentObject\JsonContentObject;
+use FriendsOfTYPO3\Headless\DataProcessing\CategoriesProcessor;
 use FriendsOfTYPO3\Headless\DataProcessing\DatabaseQueryProcessor;
 use FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor;
 use FriendsOfTYPO3\Headless\DataProcessing\FlexFormProcessor;
@@ -120,6 +121,7 @@ return static function (ContainerConfigurator $configurator): void {
             GalleryProcessor::class => ['identifier' => 'headless-gallery', 'share' => false, 'public' => false],
             DatabaseQueryProcessor::class => ['identifier' => 'headless-database-query', 'share' => false, 'public' => true],
             FlexFormProcessor::class => ['identifier' => 'headless-flex-form', 'share' => false, 'public' => false],
+            CategoriesProcessor::class => ['identifier' => 'headless-categories', 'share' => false, 'public' => false],
         ] as $class => $processorConfig
     ) {
         $service = $services->set($class)

--- a/Configuration/TypoScript/Configuration/PageConfiguration.typoscript
+++ b/Configuration/TypoScript/Configuration/PageConfiguration.typoscript
@@ -51,7 +51,18 @@ page {
                 }
             }
             meta =< lib.meta
-            categories =< lib.categories
+            categories = JSON
+            categories {
+                dataProcessing {
+                    10 = headless-categories
+                    10 {
+                        relationTable = pages
+                        relationUid.field = uid
+
+                        as = categories
+                    }
+                }
+            }
             breadcrumbs =< lib.breadcrumbs
             appearance =< lib.pageAppearance
             content =< lib.content

--- a/Configuration/TypoScript/Configuration/PageConfiguration.typoscript
+++ b/Configuration/TypoScript/Configuration/PageConfiguration.typoscript
@@ -56,9 +56,7 @@ page {
                 dataProcessing {
                     10 = headless-categories
                     10 {
-                        relationTable = pages
-                        relationUid.field = uid
-
+                        relation.fieldName = categories
                         as = categories
                     }
                 }

--- a/Configuration/TypoScript/ContentElement/ContentElement.typoscript
+++ b/Configuration/TypoScript/ContentElement/ContentElement.typoscript
@@ -23,7 +23,7 @@ lib.contentElement {
                     relationUid.field = uid
 
                     as = categories
-                  }
+                }
             }
         }
         appearance =< lib.appearance

--- a/Configuration/TypoScript/ContentElement/ContentElement.typoscript
+++ b/Configuration/TypoScript/ContentElement/ContentElement.typoscript
@@ -14,41 +14,16 @@ lib.contentElement {
         colPos {
             field = colPos
         }
-        categories = COA
+        categories = JSON
         categories {
-            10 = CONTENT
-            10 {
-                table = sys_category
-                select {
-                    pidInList = root
-                    selectFields = sys_category.title
-                    join = sys_category_record_mm on sys_category_record_mm.uid_local = sys_category.uid
-                    where {
-                        field = uid
-                        wrap = AND sys_category_record_mm.tablenames = 'tt_content' AND sys_category_record_mm.uid_foreign=|
-                    }
-                }
-                renderObj = TEXT
-                renderObj {
-                    field = title
-                    wrap = |###BREAK###
-                }
-            }
-            stdWrap.split {
-                token = ###BREAK###
-                cObjNum = 1 |*|2|*| 3
-                1 {
-                    current = 1
-                    stdWrap.wrap = |
-                }
-                2 {
-                    current = 1
-                    stdWrap.wrap = ,|
-                }
-                3 {
-                    current = 1
-                    stdWrap.wrap = |
-                }
+            dataProcessing {
+                10 = headless-categories
+                10 {
+                    relationTable = tt_content
+                    relationUid.field = uid
+
+                    as = categories
+                  }
             }
         }
         appearance =< lib.appearance

--- a/Configuration/TypoScript/ContentElement/ContentElement.typoscript
+++ b/Configuration/TypoScript/ContentElement/ContentElement.typoscript
@@ -19,8 +19,7 @@ lib.contentElement {
             dataProcessing {
                 10 = headless-categories
                 10 {
-                    relationTable = tt_content
-                    relationUid.field = uid
+                    relation.fieldName = categories
 
                     as = categories
                 }

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Used for processing flexforms.
 
 ### RootSitesProcessor
 Render your all headless sites configuration for your frontend application.
-### CatregoriesProcessor
+### CategoriesProcessor
 This processor returns an array of categories (`id` and `title`) by either a
 relation record or a comma separated list of category uids
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ Used for processing flexforms.
 
 ### RootSitesProcessor
 Render your all headless sites configuration for your frontend application.
+### CatregoriesProcessor
+This processor returns an array of categories (`id` and `title`) by either a
+relation record or a comma separated list of category uids
 
 ## Contributing
 ![Alt](https://repobeats.axiom.co/api/embed/197db91cad9195bb15a06c91fda5a215bff26cba.svg)

--- a/Tests/Functional/ContentTypes/BaseContentTypeTest.php
+++ b/Tests/Functional/ContentTypes/BaseContentTypeTest.php
@@ -25,7 +25,7 @@ abstract class BaseContentTypeTest extends BaseTest
         $this->importDataSet(__DIR__ . '/../Fixtures/content.xml');
     }
 
-    protected function checkDefaultContentFields($contentElement, $id, $pid, $type, $colPos = 0, $categories = '')
+    protected function checkDefaultContentFields($contentElement, $id, $pid, $type, $colPos = 0, $categories = [])
     {
         self::assertEquals($id, $contentElement['id'], 'id mismatch');
         self::assertEquals($type, $contentElement['type'], 'type mismatch');

--- a/Tests/Functional/ContentTypes/ShortcutElementTest.php
+++ b/Tests/Functional/ContentTypes/ShortcutElementTest.php
@@ -42,7 +42,12 @@ class ShortcutElementTest extends BaseContentTypeTest
         self::assertFalse(isset($contentElement['content']['shortcut'][0]['bodytext']));
 
         // element at pos 1 is our TextElement
-        $this->checkDefaultContentFields($contentElement['content']['shortcut'][1], 1, 1, 'text', 0, 'SysCategory1Title,SysCategory2Title');
+        $categories = [
+            ['id' => 1, 'title' => 'SysCategory1Title'],
+            ['id' => 2, 'title' => 'SysCategory2Title'],
+        ];
+
+        $this->checkDefaultContentFields($contentElement['content']['shortcut'][1], 1, 1, 'text', 0, $categories);
         $this->checkAppearanceFields($contentElement['content']['shortcut'][1], 'layout-1', 'Frame', 'SpaceBefore', 'SpaceAfter');
         $this->checkHeaderFields($contentElement['content']['shortcut'][1], 'Header', 'SubHeader', 1, 2);
         $this->checkHeaderFieldsLink($contentElement['content']['shortcut'][1], 'Page 1', '/page1?parameter=999&cHash=', '_blank');

--- a/Tests/Functional/ContentTypes/TextElementTest.php
+++ b/Tests/Functional/ContentTypes/TextElementTest.php
@@ -28,7 +28,7 @@ class TextElementTest extends BaseContentTypeTest
         $contentElement = $fullTree['content']['colPos0'][0];
         $categories = [
             ['id' => 1, 'title' => 'SysCategory1Title'],
-            ['id' => 2, 'title' => 'SysCategory2Title']
+            ['id' => 2, 'title' => 'SysCategory2Title'],
         ];
 
         $this->checkDefaultContentFields($contentElement, 1, 1, 'text', 0, $categories);

--- a/Tests/Functional/ContentTypes/TextElementTest.php
+++ b/Tests/Functional/ContentTypes/TextElementTest.php
@@ -26,8 +26,12 @@ class TextElementTest extends BaseContentTypeTest
         $fullTree = json_decode((string)$response->getBody(), true);
 
         $contentElement = $fullTree['content']['colPos0'][0];
+        $categories = [
+            ['id' => 1, 'title' => 'SysCategory1Title'],
+            ['id' => 2, 'title' => 'SysCategory2Title']
+        ];
 
-        $this->checkDefaultContentFields($contentElement, 1, 1, 'text', 0, 'SysCategory1Title,SysCategory2Title');
+        $this->checkDefaultContentFields($contentElement, 1, 1, 'text', 0, $categories);
         $this->checkAppearanceFields($contentElement, 'layout-1', 'Frame', 'SpaceBefore', 'SpaceAfter');
         $this->checkHeaderFields($contentElement, 'Header', 'SubHeader', 1, 2);
         $this->checkHeaderFieldsLink($contentElement, 'Page 1', '/page1?parameter=999&cHash=', '_blank');


### PR DESCRIPTION
With this DataProcessor we can get rid of the chunky categories TypoScript. Plus this one is easier to re-use.

Additionally to that I also re-formatted the output of the categories since we always thought that the comma-separated list is unnecessary if the data is already structured. The frontend always had to split the string into an array themselves (we never could use the string as is).
This is why I also changes the output from comma-separated list to an array of objects in the following format:

```json
    "categories": [
      {
        "id": 3,
        "title": "Test Category 1"
      },
      {
        "id": 4,
        "title": "Test Category 2"
      },
      {
        "id": 7,
        "title": "Test Category 3"
      }
    ]
```

Example usage (get categories by relation record):
```typoscript
    categories = JSON
    categories {
        dataProcessing {
            10 = headless-categories
            10 {
                relation.fieldName = categories

                as = categories
            }
        }
    }
```

Example usage (get categories by comma-separated-list of category ids):
```
    categories = JSON
    categories {
        dataProcessing {
            10 = headless-categories
            10 {
                categoryIdList = 1,3,5

                as = categories
            }
        }
    }
```