### PR TITLE
[BUGFIX] DatabaseQueryProcessor improvements

### DIFF
--- a/Configuration/TypoScript/ContentElement/MenuCategorizedContent.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuCategorizedContent.typoscript
@@ -7,7 +7,7 @@ tt_content.menu_categorized_content {
                 menu = TEXT
                 menu {
                     dataProcessing {
-                        10 = FriendsOfTYPO3\Headless\DataProcessing\DatabaseQueryProcessor
+                        10 = headless-database-query
                         10 {
                             table = tt_content
                             selectFields = {#tt_content}.*
@@ -27,10 +27,22 @@ tt_content.menu_categorized_content {
                             orderBy = tt_content.sorting
                             as = menu
                             dataProcessing {
-                                10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
+                                10 = headless-files
                                 10 {
                                     references.fieldName = image
                                     as = media
+                                }
+                            }
+
+                            fields {
+                                uid = INT
+                                uid {
+                                    field = uid
+                                }
+
+                                header = TEXT
+                                header {
+                                    field = header
                                 }
                             }
                         }

--- a/Configuration/TypoScript/ContentElement/MenuSection.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSection.typoscript
@@ -7,7 +7,7 @@ tt_content.menu_section {
                 menu = TEXT
                 menu {
                     dataProcessing {
-                        10 = FriendsOfTYPO3\Headless\DataProcessing\MenuProcessor
+                        10 = headless-menu
                         10 {
                             appendData = 1
                             as = menu
@@ -30,12 +30,12 @@ tt_content.menu_section {
                             }
 
                             dataProcessing {
-                                10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
+                                10 = headless-files
                                 10 {
                                     references.fieldName = media
                                     as = media
                                 }
-                                20 = FriendsOfTYPO3\Headless\DataProcessing\DatabaseQueryProcessor
+                                20 = headless-database-query
                                 20 {
                                     table = tt_content
                                     pidInList.field = uid
@@ -43,10 +43,22 @@ tt_content.menu_section {
                                     where = sectionIndex = 1
                                     orderBy = sorting
                                     dataProcessing {
-                                        10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
+                                        10 = headless-files
                                         10 {
                                             references.fieldName = image
                                             as = media
+                                        }
+                                    }
+
+                                    fields {
+                                        uid = INT
+                                        uid {
+                                            field = uid
+                                        }
+
+                                        header = TEXT
+                                        header {
+                                            field = header
                                         }
                                     }
                                 }

--- a/Configuration/TypoScript/ContentElement/MenuSectionPages.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSectionPages.typoscript
@@ -7,29 +7,41 @@ tt_content.menu_section_pages {
                 menu = TEXT
                 menu {
                     dataProcessing {
-                        10 = FriendsOfTYPO3\Headless\DataProcessing\MenuProcessor
+                        10 = headless-menu
                         10 {
                             appendData = 1
                             special = directory
                             special.value.field = pages
                             as = menu
                             dataProcessing {
-                                10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
+                                10 = headless-files
                                 10 {
                                     references.fieldName = media
                                     as = media
                                 }
-                                20 = FriendsOfTYPO3\Headless\DataProcessing\DatabaseQueryProcessor
+                                20 = headless-database-query
                                 20 {
                                     table = tt_content
                                     pidInList.field = uid
                                     orderBy = sorting
                                     as = content
                                     dataProcessing {
-                                        10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
+                                        10 = headless-files
                                         10 {
                                             references.fieldName = image
                                             as = media
+                                        }
+                                    }
+
+                                    fields {
+                                        uid = INT
+                                        uid {
+                                            field = uid
+                                        }
+
+                                        header = TEXT
+                                        header {
+                                            field = header
                                         }
                                     }
                                 }

--- a/Tests/Functional/ContentTypes/MenuCategorizedContentElementTest.php
+++ b/Tests/Functional/ContentTypes/MenuCategorizedContentElementTest.php
@@ -38,17 +38,13 @@ class MenuCategorizedContentElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']['menu'][1]);
 
         $firstCategorizedContentElement = $contentElement['content']['menu'][0];
-        self::assertEquals('17', $firstCategorizedContentElement['id']);
-        self::assertEquals('header', $firstCategorizedContentElement['type']);
-        self::assertEquals('default', $firstCategorizedContentElement['appearance']['frameClass']);
-        self::assertEquals('1', $firstCategorizedContentElement['colPos']);
-        self::assertEquals('SysCategory3Title', $firstCategorizedContentElement['categories']);
+        self::assertSame(17, $firstCategorizedContentElement['uid']);
+        self::assertArrayHasKey('header', $firstCategorizedContentElement);
+        self::assertArrayHasKey('media', $firstCategorizedContentElement);
 
         $secondCategorizedContentElement = $contentElement['content']['menu'][1];
-        self::assertEquals('18', $secondCategorizedContentElement['id']);
-        self::assertEquals('textpic', $secondCategorizedContentElement['type']);
-        self::assertEquals('default', $secondCategorizedContentElement['appearance']['frameClass']);
-        self::assertEquals('1', $secondCategorizedContentElement['colPos']);
-        self::assertEquals('SysCategory3Title', $secondCategorizedContentElement['categories']);
+        self::assertSame(18, $secondCategorizedContentElement['uid']);
+        self::assertArrayHasKey('header', $secondCategorizedContentElement);
+        self::assertArrayHasKey('media', $secondCategorizedContentElement);
     }
 }


### PR DESCRIPTION
- restore behavior to output whole record if rendering definition is not set for query processor (resolves: #718)
- align menus to render less data (only uid, header & processed image if set) to match core fluid-style-content behavior & solve performance issues (resolves: #715)
- code cleanup