### PR TITLE
[FEATURE] Add `nullableFieldsIfEmpty` option to JsonContentObject

### DIFF
--- a/Classes/ContentObject/JsonContentObject.php
+++ b/Classes/ContentObject/JsonContentObject.php
@@ -97,6 +97,7 @@ class JsonContentObject extends AbstractContentObject implements LoggerAwareInte
     public function cObjGet(array $setup, string $addKey = ''): array
     {
         $content = [];
+        $nullableFieldsIfEmpty = GeneralUtility::trimExplode(',', $this->conf['nullableFieldsIfEmpty'] ?? '', true);
 
         $sKeyArray = $this->filterByStringKeys($setup);
         foreach ($sKeyArray as $theKey) {
@@ -117,7 +118,7 @@ class JsonContentObject extends AbstractContentObject implements LoggerAwareInte
                 if ($theValue === 'USER_INT' || str_starts_with((string)$content[$theKey], '<!--INT_SCRIPT.')) {
                     $content[$theKey] = $this->headlessUserInt->wrap($content[$theKey], (int)($conf['ifEmptyReturnNull'] ?? 0) === 1 ? HeadlessUserInt::STANDARD_NULLABLE : HeadlessUserInt::STANDARD);
                 }
-                if ((int)($conf['ifEmptyReturnNull'] ?? 0) === 1 && $content[$theKey] === '') {
+                if ($content[$theKey] === '' && ((int)($conf['ifEmptyReturnNull'] ?? 0) === 1 || in_array($theKey, $nullableFieldsIfEmpty, true))) {
                     $content[$theKey] = null;
                 }
                 if ((int)($conf['ifEmptyUnsetKey'] ?? 0) === 1 && ($content[$theKey] === '' || $content[$theKey] === false)) {

--- a/Tests/Unit/ContentObject/JsonContentObjectTest.php
+++ b/Tests/Unit/ContentObject/JsonContentObjectTest.php
@@ -148,6 +148,7 @@ class JsonContentObjectTest extends UnitTestCase
             [[], '[]'],
             [null, '[]'],
             [['fields.' => ['test' => 'TEXT', 'test.' => ['value' => '', 'ifEmptyUnsetKey' => 1]]], json_encode([])],
+            [['nullableFieldsIfEmpty' => 'test,test3', 'fields.' => ['test' => 'TEXT', 'test.' => ['value' => ''], 'test2' => 'TEXT', 'test2.' => ['value' => '1'], 'test3' => 'TEXT', 'test3.' => ['value' => '']]], json_encode(['test' => null, 'test2' => '1', 'test3' => null])],
             [['fields.' => ['test' => 'INT', 'test.' => ['value' => '1', 'ifEmptyUnsetKey' => 1]]], json_encode(['test' => 1])],
             [['if.' => ['isTrue' => 0], 'fields.' => ['test' => 'TEXT', 'test.' => ['value' => '1']]], ''],
             [['if.' => ['isTrue' => 1], 'fields.' => ['test' => 'TEXT', 'test.' => ['value' => '1']]], json_encode(['test' => '1'])],


### PR DESCRIPTION
This new option adds ability to define which fields should be set to null when parsed TypoScript returns empty string