### PR TITLE
Update PreviewController.php -> add use HeadlessModeInterface

### DIFF
--- a/Classes/XClass/Controller/PreviewController.php
+++ b/Classes/XClass/Controller/PreviewController.php
@@ -15,6 +15,8 @@ use FriendsOfTYPO3\Headless\Utility\HeadlessModeInterface;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use FriendsOfTYPO3\Headless\Utility\HeadlessModeInterface;
+
 
 /**
  * This XClass allows you to render frontend URLs for workspaces


### PR DESCRIPTION
Added missing "use FriendsOfTYPO3\Headless\Utility\HeadlessModeInterface", causing Error when trying to access the workspace preview.