### PR TITLE
[BUGFIX] Fix TypeError in HeadlessUserInt::unwrap() when preg_replace_callback returns null

### DIFF
--- a/Classes/Utility/HeadlessUserInt.php
+++ b/Classes/Utility/HeadlessUserInt.php
@@ -49,7 +49,7 @@ class HeadlessUserInt
                 sprintf(self::REGEX, self::NESTED, self::NESTED),
                 [$this, 'replace'],
                 $content
-            );
+            ) ?? $content;
         }
 
         if (str_contains($content, self::NESTED_NULLABLE)) {
@@ -59,7 +59,7 @@ class HeadlessUserInt
                     return $this->replace($content, true);
                 },
                 $content
-            );
+            ) ?? $content;
         }
 
         if (str_contains($content, self::STANDARD_NULLABLE)) {
@@ -69,14 +69,14 @@ class HeadlessUserInt
                     return $this->replace($content, true);
                 },
                 $content
-            );
+            ) ?? $content;
         }
 
         return preg_replace_callback(
             sprintf(self::REGEX, self::STANDARD, self::STANDARD),
             [$this, 'replace'],
             $content
-        );
+        ) ?? $content;
     }
 
     /**


### PR DESCRIPTION
## Problem

`HeadlessUserInt::unwrap()` declares `string` as its return type, but `preg_replace_callback()` can return `null` on internal failure (as documented in the [PHP manual](https://www.php.net/manual/en/function.preg-replace-callback.php)).

This causes a sporadic `TypeError` in production environments:
TypeError: FriendsOfTYPO3\Headless\Utility\HeadlessUserInt::unwrap(): Return value must be of type string, null returned
The issue is intermittent and hard to reproduce, but occurs under real-world load.

## Fix

Add the null coalescing operator (`?? $content`) to all four `preg_replace_callback()` calls in `unwrap()`, so the original content is preserved instead of returning `null`.

This is the minimal, non-breaking fix — no behavioral change when `preg_replace_callback()` succeeds.

## Changes

 - `Classes/Utility/HeadlessUserInt.php`: Add `?? $content` to all 4 `preg_replace_callback()` calls