### PR TITLE
Prevent fatal error

### DIFF
--- a/Classes/Seo/MetaTag/AbstractMetaTagManager.php
+++ b/Classes/Seo/MetaTag/AbstractMetaTagManager.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Headless\Seo\MetaTag;
 
 use FriendsOfTYPO3\Headless\Utility\HeadlessModeInterface;
+use TYPO3\CMS\Core\Type\DocType;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 use function array_merge;
@@ -23,7 +24,7 @@ use function json_encode;
  */
 abstract class AbstractMetaTagManager extends \TYPO3\CMS\Core\MetaTag\AbstractMetaTagManager
 {
-    public function renderAllProperties(): string
+    public function renderAllProperties(DocType|null $docType = null): string
     {
         if (GeneralUtility::makeInstance(HeadlessModeInterface::class)->withRequest($GLOBALS['TYPO3_REQUEST'])->isEnabled()) {
             return $this->renderAllHeadlessProperties();
@@ -32,7 +33,7 @@ abstract class AbstractMetaTagManager extends \TYPO3\CMS\Core\MetaTag\AbstractMe
         return parent::renderAllProperties();
     }
 
-    public function renderProperty(string $property): string
+    public function renderProperty(string $property, ?DocType $docType = null): string
     {
         if (GeneralUtility::makeInstance(HeadlessModeInterface::class)->withRequest($GLOBALS['TYPO3_REQUEST'])->isEnabled()) {
             return $this->renderHeadlessProperty($property);


### PR DESCRIPTION
Prevent fatal error:

Fatal error: Declaration of FriendsOfTYPO3\Headless\Seo\MetaTag\AbstractMetaTagManager::renderProperty(string $property): string must be compatible with TYPO3\CMS\Core\MetaTag\AbstractMetaTagManager::renderProperty(string $property, ?TYPO3\CMS\Core\Type\DocType $docType = null): string