### PR TITLE
[BUGFIX] Fix link genration for TYPO3 14

### DIFF
--- a/Classes/Hooks/FileOrFolderLinkBuilder.php
+++ b/Classes/Hooks/FileOrFolderLinkBuilder.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Headless\Hooks;
 
 use FriendsOfTYPO3\Headless\Utility\HeadlessModeInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
 use TYPO3\CMS\Frontend\Typolink\UnableToLinkException;
 
@@ -20,22 +22,27 @@ use TYPO3\CMS\Frontend\Typolink\UnableToLinkException;
  */
 class FileOrFolderLinkBuilder extends \TYPO3\CMS\Frontend\Typolink\FileOrFolderLinkBuilder
 {
-    public function __construct(private readonly HeadlessModeInterface $headlessMode) {}
+    public function __construct(protected ?HeadlessModeInterface $headlessMode = null) {}
+
+    protected function getHeadlessMode(): HeadlessModeInterface
+    {
+        return $this->headlessMode ??= GeneralUtility::makeInstance(HeadlessModeInterface::class);
+    }
 
     /**
-     * {@inheritDoc}
      * @throws UnableToLinkException
      */
-    public function build(array &$linkDetails, string $linkText, string $target, array $conf): LinkResultInterface
+    public function buildLink(
+        array $linkDetails,
+        array $configuration,
+        ServerRequestInterface $request,
+        string $linkText = '',
+    ): LinkResultInterface
     {
-        if (!isset($GLOBALS['TYPO3_REQUEST'])) {
-            return parent::build($linkDetails, $linkText, $target, $conf);
+        if ($this->getHeadlessMode()->withRequest($request)->isEnabled()) {
+            $configuration['forceAbsoluteUrl'] = 1;
         }
 
-        if ($this->headlessMode->withRequest($GLOBALS['TYPO3_REQUEST'])->isEnabled()) {
-            $conf['forceAbsoluteUrl'] = 1;
-        }
-
-        return parent::build($linkDetails, $linkText, $target, $conf);
+        return parent::buildLink($linkDetails, $configuration, $request, $linkText);
     }
 }

--- a/Classes/Seo/CanonicalGenerator.php
+++ b/Classes/Seo/CanonicalGenerator.php
@@ -25,7 +25,12 @@ use function json_encode;
  */
 class CanonicalGenerator
 {
-    public function __construct(private readonly HeadlessModeInterface $headlessMode) {}
+    public function __construct(protected ?HeadlessModeInterface $headlessMode = null) {}
+
+    protected function getHeadlessMode(): HeadlessModeInterface
+    {
+        return $this->headlessMode ??= GeneralUtility::makeInstance(HeadlessModeInterface::class);
+    }
 
     public function handle(array &$params): string
     {
@@ -35,7 +40,7 @@ class CanonicalGenerator
             return '';
         }
 
-        if ($this->headlessMode->withRequest($params['request'])->isEnabled()) {
+        if ($this->getHeadlessMode()->withRequest($params['request'])->isEnabled()) {
             $canonical = [
                 'href' => $this->processCanonical($canonical),
                 'rel' => 'canonical',


### PR DESCRIPTION
Classes registered through legacy TYPO3 configuration entry points should be instantiable without constructor arguments, or should be registered in a way that guarantees container-based DI.

The file typolink builder should implement TYPO3 14 `buildLink(...)`.

Make `HeadlessModeInterface` optional in those legacy-instantiated classes and lazy-load it via `GeneralUtility::makeInstance(HeadlessModeInterface::class)` when needed.

Update `FileOrFolderLinkBuilder` to implement `buildLink(array $linkDetails, array $configuration, ServerRequestInterface $request, string $linkText = '')` and call the TYPO3 14 parent `buildLink(...)`.

Fixes: #885
Refs: #865