### PR TITLE
[BUGFIX] Decouple title and seo_title in lib.meta

### DIFF
--- a/Configuration/TypoScript/Page/Meta.typoscript
+++ b/Configuration/TypoScript/Page/Meta.typoscript
@@ -4,11 +4,11 @@ lib.meta {
     fields {
         title = TEXT
         title {
+            field = title
+        }
+        seoTitle = TEXT
+        seoTitle {
             field = seo_title
-            stdWrap.ifEmpty.cObject = TEXT
-            stdWrap.ifEmpty.cObject {
-                field = title
-            }
         }
         subtitle = TEXT
         subtitle {


### PR DESCRIPTION
 hardcoded a fallback to , which overwrote the actual page title in the JSON API payload. Both fields are now returned independently.

Resolves: #906